### PR TITLE
feat: add localhost HTTP API server for external integrations

### DIFF
--- a/apps/desktop/src/main/managers/http-api-manager.ts
+++ b/apps/desktop/src/main/managers/http-api-manager.ts
@@ -1,0 +1,98 @@
+import { createHTTPHandler } from "@trpc/server/adapters/standalone";
+import * as http from "node:http";
+import type { Server } from "node:http";
+import { logger } from "../logger";
+import { router } from "../../trpc/router";
+import { createContext } from "../../trpc/context";
+import type { ServiceManager } from "./service-manager";
+
+const DEFAULT_PORT = 21417;
+
+/**
+ * Manages the localhost HTTP API server for external integrations
+ * Exposes the tRPC router over HTTP on localhost only
+ */
+export class HttpApiManager {
+  private server: Server | null = null;
+  private serviceManager: ServiceManager;
+  private port: number;
+
+  constructor(serviceManager: ServiceManager, port: number = DEFAULT_PORT) {
+    this.serviceManager = serviceManager;
+    this.port = port;
+  }
+
+  async start(): Promise<void> {
+    if (this.server) {
+      logger.main.warn("HTTP API server is already running");
+      return;
+    }
+
+    try {
+      const trpcHandler = createHTTPHandler({
+        router,
+        createContext: async () => createContext(this.serviceManager),
+      });
+
+      this.server = http.createServer((req, res) => {
+        // CORS headers for local development
+        res.setHeader("Access-Control-Allow-Origin", "*");
+        res.setHeader(
+          "Access-Control-Allow-Methods",
+          "GET, POST, OPTIONS"
+        );
+        res.setHeader(
+          "Access-Control-Allow-Headers",
+          "Content-Type, Authorization"
+        );
+
+        // Handle preflight requests
+        if (req.method === "OPTIONS") {
+          res.writeHead(200);
+          res.end();
+          return;
+        }
+
+        trpcHandler(req, res);
+      });
+
+      // Listen only on localhost for security
+      await new Promise<void>((resolve, reject) => {
+        this.server!.listen(this.port, "127.0.0.1", () => {
+          logger.main.info(`HTTP API server started on http://127.0.0.1:${this.port}`);
+          resolve();
+        });
+
+        this.server!.on("error", (error: NodeJS.ErrnoException) => {
+          if (error.code === "EADDRINUSE") {
+            logger.main.warn(`Port ${this.port} is already in use, HTTP API server not started`);
+            this.server = null;
+            resolve(); // Don't fail, just skip
+          } else {
+            reject(error);
+          }
+        });
+      });
+    } catch (error) {
+      logger.main.error("Failed to start HTTP API server:", error);
+      throw error;
+    }
+  }
+
+  stop(): void {
+    if (this.server) {
+      this.server.close(() => {
+        logger.main.info("HTTP API server stopped");
+      });
+      this.server = null;
+    }
+  }
+
+  isRunning(): boolean {
+    return this.server !== null;
+  }
+
+  getPort(): number {
+    return this.port;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `HttpApiManager` to expose the existing tRPC router over HTTP on localhost
- Server runs on port `21417` (127.0.0.1 only for security)
- Includes CORS headers for local development
- Gracefully handles port conflicts (doesn't fail if port is in use)
- Integrates with `ServiceManager` lifecycle (automatic start/stop)

## Usage

Once the desktop app is running, you can access the tRPC API at:
```
http://127.0.0.1:21417/
```

Example (get transcriptions):
```bash
curl -X POST http://127.0.0.1:21417/transcriptions.getTranscriptions \
  -H "Content-Type: application/json" \
  -d '{"json":{"limit":10,"offset":0,"sortBy":"timestamp","sortOrder":"desc"}}'
```

## Test plan
- [ ] Start the desktop app and verify HTTP API server starts (check logs)
- [ ] Test API endpoint with curl or browser
- [ ] Verify CORS headers work from browser
- [ ] Verify server stops cleanly on app quit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a local HTTP API server to expose application functionality over HTTP with configurable port settings (default: 21417)
  * Integrated HTTP server lifecycle management with automatic startup, status monitoring, and graceful shutdown
  * Enabled CORS configuration for seamless local development and third-party integrations
  * Added proper error handling for port conflicts and server startup scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->