### PR TITLE
feat: add preference to show/hide widget while recording

### DIFF
--- a/apps/desktop/src/db/app-settings.ts
+++ b/apps/desktop/src/db/app-settings.ts
@@ -140,6 +140,7 @@ const defaultSettings: AppSettingsData = {
   preferences: {
     launchAtLogin: true,
     showWidgetWhileInactive: true,
+    showWidgetWhileActive: true,
     showInDock: true,
   },
   transcription: {

--- a/apps/desktop/src/db/schema.ts
+++ b/apps/desktop/src/db/schema.ts
@@ -158,6 +158,7 @@ export interface AppSettingsData {
     launchAtLogin?: boolean;
     minimizeToTray?: boolean;
     showWidgetWhileInactive?: boolean;
+    showWidgetWhileActive?: boolean;
     showInDock?: boolean;
   };
   telemetry?: {

--- a/apps/desktop/src/main/core/app-manager.ts
+++ b/apps/desktop/src/main/core/app-manager.ts
@@ -188,12 +188,14 @@ export class AppManager {
       "preferences-changed",
       async ({
         showWidgetWhileInactiveChanged,
+        showWidgetWhileActiveChanged,
         showInDockChanged,
       }: {
         showWidgetWhileInactiveChanged: boolean;
+        showWidgetWhileActiveChanged: boolean;
         showInDockChanged: boolean;
       }) => {
-        if (showWidgetWhileInactiveChanged) {
+        if (showWidgetWhileInactiveChanged || showWidgetWhileActiveChanged) {
           const recordingManager =
             this.serviceManager.getService("recordingManager");
           const isIdle = recordingManager.getState() === "idle";
@@ -217,7 +219,11 @@ export class AppManager {
     const settingsService = this.serviceManager.getService("settingsService");
     const preferences = await settingsService.getPreferences();
 
-    if (preferences.showWidgetWhileInactive || !isIdle) {
+    const shouldShow = isIdle
+      ? preferences.showWidgetWhileInactive
+      : preferences.showWidgetWhileActive;
+
+    if (shouldShow) {
       this.windowManager.showWidget();
     } else {
       this.windowManager.hideWidget();

--- a/apps/desktop/src/renderer/main/pages/settings/preferences/index.tsx
+++ b/apps/desktop/src/renderer/main/pages/settings/preferences/index.tsx
@@ -34,6 +34,12 @@ export default function PreferencesSettingsPage() {
     });
   };
 
+  const handleShowWidgetWhileActiveChange = (checked: boolean) => {
+    updatePreferencesMutation.mutate({
+      showWidgetWhileActive: checked,
+    });
+  };
+
   const handleMinimizeToTrayChange = (checked: boolean) => {
     updatePreferencesMutation.mutate({
       minimizeToTray: checked,
@@ -48,6 +54,8 @@ export default function PreferencesSettingsPage() {
 
   const showWidgetWhileInactive =
     preferencesQuery.data?.showWidgetWhileInactive ?? true;
+  const showWidgetWhileActive =
+    preferencesQuery.data?.showWidgetWhileActive ?? true;
   const minimizeToTray = preferencesQuery.data?.minimizeToTray ?? false;
   const launchAtLogin = preferencesQuery.data?.launchAtLogin ?? true;
   const showInDock = preferencesQuery.data?.showInDock ?? true;
@@ -117,6 +125,25 @@ export default function PreferencesSettingsPage() {
               <Switch
                 checked={showWidgetWhileInactive}
                 onCheckedChange={handleShowWidgetWhileInactiveChange}
+                disabled={updatePreferencesMutation.isPending}
+              />
+            </div>
+
+            <Separator />
+
+            {/* Show Widget While Active Section */}
+            <div className="flex items-center justify-between">
+              <div className="space-y-1">
+                <Label className="text-base font-medium text-foreground">
+                  Show widget while active
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Show the widget on screen when recording
+                </p>
+              </div>
+              <Switch
+                checked={showWidgetWhileActive}
+                onCheckedChange={handleShowWidgetWhileActiveChange}
                 disabled={updatePreferencesMutation.isPending}
               />
             </div>

--- a/apps/desktop/src/services/settings-service.ts
+++ b/apps/desktop/src/services/settings-service.ts
@@ -21,6 +21,7 @@ export interface AppPreferences {
   launchAtLogin: boolean;
   minimizeToTray: boolean;
   showWidgetWhileInactive: boolean;
+  showWidgetWhileActive: boolean;
   showInDock: boolean;
 }
 
@@ -289,6 +290,7 @@ export class SettingsService extends EventEmitter {
       launchAtLogin: preferences?.launchAtLogin ?? true,
       minimizeToTray: preferences?.minimizeToTray ?? true,
       showWidgetWhileInactive: preferences?.showWidgetWhileInactive ?? true,
+      showWidgetWhileActive: preferences?.showWidgetWhileActive ?? true,
       showInDock: preferences?.showInDock ?? true,
     };
   }
@@ -316,6 +318,8 @@ export class SettingsService extends EventEmitter {
       changes: preferences,
       showWidgetWhileInactiveChanged:
         preferences.showWidgetWhileInactive !== undefined,
+      showWidgetWhileActiveChanged:
+        preferences.showWidgetWhileActive !== undefined,
       showInDockChanged: preferences.showInDock !== undefined,
     });
   }

--- a/apps/desktop/src/trpc/routers/settings.ts
+++ b/apps/desktop/src/trpc/routers/settings.ts
@@ -43,6 +43,7 @@ const AppPreferencesSchema = z.object({
   launchAtLogin: z.boolean().optional(),
   minimizeToTray: z.boolean().optional(),
   showWidgetWhileInactive: z.boolean().optional(),
+  showWidgetWhileActive: z.boolean().optional(),
   showInDock: z.boolean().optional(),
 });
 


### PR DESCRIPTION
Adds a new "Show widget while active" toggle in preferences that allows
  users to control whether the recording widget is visible during active
  recording sessions. Previously the widget was always shown when recording.

  The changes add:
  - New showWidgetWhileActive preference with UI toggle
  - Logic in app-manager.ts to conditionally show/hide widget based on recording state
  - Schema, settings service, and tRPC updates to support the new setting

# Why

  When using tiling window managers like Aerospace, the recording widget appearing can be
  disruptive. These window managers automatically manage window focus and workspace
  placement, so when the widget appears and takes focus, it can:

  - Trigger an unwanted workspace/space change
  - Unfocus the window you're currently working in
  - Disrupt your workflow by rearranging windows

  This preference allows users to hide the widget during active recording, avoiding these
  focus-stealing issues while still being able to record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Show widget while active" preference so you can control widget visibility when the app is in use separately from when it's idle.
  * Settings now include a toggle for this option and the app will update widget visibility immediately when either active or inactive visibility preferences change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->