### PR TITLE
fix: support CJK languages in vocabulary replacement

### DIFF
--- a/apps/desktop/src/utils/text-replacement.ts
+++ b/apps/desktop/src/utils/text-replacement.ts
@@ -1,0 +1,45 @@
+/**
+ * Apply vocabulary replacements to text.
+ * Uses word boundaries for alphabetic languages, simple replacement for CJK.
+ *
+ * @param text - The text to apply replacements to
+ * @param replacements - Map of words to their replacements
+ * @returns The text with replacements applied
+ */
+export function applyTextReplacements(
+  text: string,
+  replacements: Map<string, string>,
+): string {
+  if (replacements.size === 0 || !text) {
+    return text;
+  }
+
+  let result = text;
+
+  // CJK character detection: Han (Chinese/Japanese Kanji), Hiragana, Katakana, Hangul (Korean)
+  const cjkPattern =
+    /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+
+  for (const [word, replacement] of replacements) {
+    // Escape special regex characters in the word
+    const escapedWord = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const hasCJK = cjkPattern.test(word);
+
+    if (hasCJK) {
+      // CJK: Simple case-insensitive replacement (no word boundaries)
+      // Japanese/Chinese/Korean text has no spaces between words
+      const regex = new RegExp(escapedWord, "giu");
+      result = result.replace(regex, replacement);
+    } else {
+      // Alphabetic languages: Use Unicode-aware word boundary matching
+      // Negative lookbehind/lookahead ensures word is not part of a larger word
+      const regex = new RegExp(
+        `(?<![\\p{L}\\p{N}])${escapedWord}(?![\\p{L}\\p{N}])`,
+        "giu",
+      );
+      result = result.replace(regex, replacement);
+    }
+  }
+
+  return result;
+}

--- a/apps/desktop/tests/utils/text-replacement.test.ts
+++ b/apps/desktop/tests/utils/text-replacement.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { applyTextReplacements } from "../../src/utils/text-replacement";
+
+describe("applyTextReplacements", () => {
+  describe("English (alphabetic languages)", () => {
+    it("should replace English words with word boundaries", () => {
+      const replacements = new Map([["apple", "りんご"]]);
+      const result = applyTextReplacements("I like apple today", replacements);
+      expect(result).toBe("I like りんご today");
+    });
+
+    it("should not replace partial matches in English", () => {
+      const replacements = new Map([["apple", "りんご"]]);
+      const result = applyTextReplacements(
+        "I like pineapple today",
+        replacements,
+      );
+      expect(result).toBe("I like pineapple today");
+    });
+
+    it("should replace multiple occurrences", () => {
+      const replacements = new Map([["test", "テスト"]]);
+      const result = applyTextReplacements(
+        "test is a test for test",
+        replacements,
+      );
+      expect(result).toBe("テスト is a テスト for テスト");
+    });
+
+    it("should be case-insensitive for English", () => {
+      const replacements = new Map([["apple", "りんご"]]);
+      const result = applyTextReplacements("I like APPLE today", replacements);
+      expect(result).toBe("I like りんご today");
+    });
+  });
+
+  describe("Japanese", () => {
+    it("should replace Japanese words without word boundaries", () => {
+      const replacements = new Map([["天気", "☀️"]]);
+      const result = applyTextReplacements("今日は天気がいい", replacements);
+      expect(result).toBe("今日は☀️がいい");
+    });
+
+    it("should replace hiragana words", () => {
+      const replacements = new Map([["ありがとう", "🙏"]]);
+      const result = applyTextReplacements(
+        "ありがとうございます",
+        replacements,
+      );
+      expect(result).toBe("🙏ございます");
+    });
+
+    it("should replace katakana words", () => {
+      const replacements = new Map([["コーヒー", "☕"]]);
+      const result = applyTextReplacements(
+        "私はコーヒーが好きです",
+        replacements,
+      );
+      expect(result).toBe("私は☕が好きです");
+    });
+
+    it("should replace multiple Japanese words", () => {
+      const replacements = new Map([
+        ["天気", "☀️"],
+        ["今日", "📅"],
+      ]);
+      const result = applyTextReplacements("今日は天気がいい", replacements);
+      expect(result).toBe("📅は☀️がいい");
+    });
+  });
+
+  describe("Chinese", () => {
+    it("should replace Chinese words", () => {
+      const replacements = new Map([["你好", "👋"]]);
+      const result = applyTextReplacements("你好世界", replacements);
+      expect(result).toBe("👋世界");
+    });
+  });
+
+  describe("Korean", () => {
+    it("should replace Korean words", () => {
+      const replacements = new Map([["안녕", "👋"]]);
+      const result = applyTextReplacements("안녕하세요", replacements);
+      expect(result).toBe("👋하세요");
+    });
+  });
+
+  describe("Mixed language", () => {
+    it("should handle mixed CJK and English replacements", () => {
+      const replacements = new Map([
+        ["天気", "weather"],
+        ["good", "良い"],
+      ]);
+      const result = applyTextReplacements(
+        "今日の天気は good です",
+        replacements,
+      );
+      expect(result).toBe("今日のweatherは 良い です");
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle empty text", () => {
+      const replacements = new Map([["test", "テスト"]]);
+      const result = applyTextReplacements("", replacements);
+      expect(result).toBe("");
+    });
+
+    it("should handle empty replacements", () => {
+      const replacements = new Map<string, string>();
+      const result = applyTextReplacements("hello world", replacements);
+      expect(result).toBe("hello world");
+    });
+
+    it("should handle special regex characters in words", () => {
+      const replacements = new Map([["C++", "シープラプラ"]]);
+      const result = applyTextReplacements(
+        "I program in C++ language",
+        replacements,
+      );
+      expect(result).toBe("I program in シープラプラ language");
+    });
+
+    it("should handle replacement to empty string", () => {
+      const replacements = new Map([["削除", ""]]);
+      const result = applyTextReplacements("これを削除します", replacements);
+      expect(result).toBe("これをします");
+    });
+
+    it("should handle word at start of text", () => {
+      const replacements = new Map([["Hello", "こんにちは"]]);
+      const result = applyTextReplacements("Hello world", replacements);
+      expect(result).toBe("こんにちは world");
+    });
+
+    it("should handle word at end of text", () => {
+      const replacements = new Map([["world", "世界"]]);
+      const result = applyTextReplacements("Hello world", replacements);
+      expect(result).toBe("Hello 世界");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix vocabulary replacement not working for Japanese, Chinese, and Korean text
- Extract replacement logic to a testable pure function
- Add CJK character detection to skip word boundary checks for CJK languages

## Changes

- **New file**: `apps/desktop/src/utils/text-replacement.ts` - Pure function for text replacement with CJK support
- **Modified**: `apps/desktop/src/services/transcription-service.ts` - Use the new utility function
- **New file**: `apps/desktop/tests/utils/text-replacement.test.ts` - Unit tests

## Root Cause

The word boundary regex `(?<![\\p{L}\\p{N}])word(?![\\p{L}\\p{N}])` fails for CJK languages because they don't have spaces between words.

## Solution

Detect CJK characters using Unicode Script properties and skip word boundary check for those words:

```typescript
const cjkPattern = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
```

## Test Plan

- [x] Unit tests pass for English, Japanese, Chinese, Korean
- [ ] Manual test: Add Japanese replacement in Settings → Vocabulary, verify it works

Fixes #80

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced multilingual text replacement for transcriptions with language-aware processing, including improved support for CJK scripts (Chinese, Japanese, Korean) and better word-boundary detection for alphabetic languages.

* **Refactor**
  * Optimized internal text replacement logic for improved accuracy and consistency across different language types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->