### PR TITLE
fix: mobile sidebar overlapping header

### DIFF
--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -49,6 +49,7 @@ body {
   --sidebar-ring: oklch(0.708 0 0);
   --content-padding: 2rem;
   --content-max-width: 75rem;
+  --header-height: 3rem;
 }
 
 .dark {


### PR DESCRIPTION
Move --header-height CSS variable to :root in globals.css so it's available to the Sheet portal which renders outside the SidebarProvider context. This ensures the sidebar content is properly positioned below the header on all platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated desktop application styling with a new header height design token.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->