### PR TITLE
fix: vocabulary replacement fails for English words adjacent to CJK characters

### DIFF
--- a/apps/desktop/src/utils/text-replacement.ts
+++ b/apps/desktop/src/utils/text-replacement.ts
@@ -31,10 +31,11 @@ export function applyTextReplacements(
       const regex = new RegExp(escapedWord, "giu");
       result = result.replace(regex, replacement);
     } else {
-      // Alphabetic languages: Use Unicode-aware word boundary matching
-      // Negative lookbehind/lookahead ensures word is not part of a larger word
+      // Alphabetic languages: Use word boundary matching
+      // Only check Latin script boundaries to prevent "apple" matching in "pineapple"
+      // but allow matching adjacent to CJK characters (e.g., "Xavixの設定")
       const regex = new RegExp(
-        `(?<![\\p{L}\\p{N}])${escapedWord}(?![\\p{L}\\p{N}])`,
+        `(?<![\\p{Script=Latin}\\p{N}])${escapedWord}(?![\\p{Script=Latin}\\p{N}])`,
         "giu",
       );
       result = result.replace(regex, replacement);


### PR DESCRIPTION
## Summary

- Fix vocabulary replacement regex that fails when English words appear adjacent to CJK (Japanese/Chinese/Korean) characters
- Change `\p{L}` to `\p{Script=Latin}` in word boundary lookahead/lookbehind
- Latin word boundary protection still works (e.g., "apple" in "pineapple" is not replaced)

## Problem

The word boundary regex in `applyTextReplacements()` uses `\p{L}` (all Unicode letters) in negative lookahead/lookbehind. Since `\p{L}` matches CJK characters, English words adjacent to Japanese text (e.g., `Xavix` in `Xavixの設定`) are never replaced because the CJK character triggers the boundary check.

### Example

With vocabulary entry `Xavix → ZABBIX`:
- Input: `Xavixの設定`
- Before fix: `Xavixの設定` (no replacement - `の` matches `\p{L}`)
- After fix: `ZABBIXの設定` (correctly replaced - `の` doesn't match `\p{Script=Latin}`)

## Changes

`apps/desktop/src/utils/text-replacement.ts`:
- Replace `\p{L}` with `\p{Script=Latin}` in the word boundary regex
- This ensures only Latin script characters are considered for word boundaries
- CJK characters adjacent to English words no longer block replacement

## Test Plan

- [x] Verified `Xavixの設定` → `ZABBIXの設定` works correctly
- [x] Verified `pineapple` does not have `apple` replaced (Latin boundary still works)
- [x] Verified pure CJK replacements (e.g., `ザビックス` → `ZABBIX`) still work
- [x] Tested with Amical Cloud transcription on Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text replacement now properly handles mixed-script text, including CJK characters alongside Latin characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->