### PR TITLE
feat: add setting to keep transcript in clipboard after pasting

### DIFF
--- a/apps/desktop/src/db/app-settings.ts
+++ b/apps/desktop/src/db/app-settings.ts
@@ -80,7 +80,7 @@ const defaultSettings: AppSettingsData = {
     muteSystemAudio: true,
     muteDictationSounds: false,
     autoDictateOnNewNote: false,
-    keepTranscriptInClipboard: false,
+    preserveClipboard: true,
   },
   transcription: {
     language: "en",

--- a/apps/desktop/src/db/app-settings.ts
+++ b/apps/desktop/src/db/app-settings.ts
@@ -80,6 +80,7 @@ const defaultSettings: AppSettingsData = {
     muteSystemAudio: true,
     muteDictationSounds: false,
     autoDictateOnNewNote: false,
+    keepTranscriptInClipboard: false,
   },
   transcription: {
     language: "en",

--- a/apps/desktop/src/db/schema.ts
+++ b/apps/desktop/src/db/schema.ts
@@ -178,6 +178,7 @@ export interface AppSettingsData {
     muteSystemAudio?: boolean;
     muteDictationSounds?: boolean;
     autoDictateOnNewNote?: boolean;
+    keepTranscriptInClipboard?: boolean;
   };
   telemetry?: {
     enabled?: boolean;

--- a/apps/desktop/src/db/schema.ts
+++ b/apps/desktop/src/db/schema.ts
@@ -178,7 +178,7 @@ export interface AppSettingsData {
     muteSystemAudio?: boolean;
     muteDictationSounds?: boolean;
     autoDictateOnNewNote?: boolean;
-    keepTranscriptInClipboard?: boolean;
+    preserveClipboard?: boolean;
   };
   telemetry?: {
     enabled?: boolean;

--- a/apps/desktop/src/db/settings-migrations/index.ts
+++ b/apps/desktop/src/db/settings-migrations/index.ts
@@ -7,11 +7,12 @@ import { migrateToV6 } from "./v6";
 import { migrateToV7 } from "./v7";
 import { migrateToV8 } from "./v8";
 import { migrateToV9 } from "./v9";
+import { migrateToV10 } from "./v10";
 
 export type MigrationFn = (data: unknown) => AppSettingsData;
 
 // Current settings schema version - increment when making breaking changes
-export const CURRENT_SETTINGS_VERSION = 9;
+export const CURRENT_SETTINGS_VERSION = 10;
 
 const migrations: Record<number, MigrationFn> = {
   2: migrateToV2,
@@ -22,6 +23,7 @@ const migrations: Record<number, MigrationFn> = {
   7: migrateToV7,
   8: migrateToV8,
   9: migrateToV9,
+  10: migrateToV10,
 };
 
 /**

--- a/apps/desktop/src/db/settings-migrations/v10.ts
+++ b/apps/desktop/src/db/settings-migrations/v10.ts
@@ -1,0 +1,15 @@
+import type { AppSettingsData } from "../schema";
+
+// v9 -> v10: add keepTranscriptInClipboard preference
+export function migrateToV10(data: unknown): AppSettingsData {
+  const oldData = data as AppSettingsData;
+  const preferences = oldData.preferences ?? {};
+
+  return {
+    ...oldData,
+    preferences: {
+      ...preferences,
+      keepTranscriptInClipboard: false,
+    },
+  };
+}

--- a/apps/desktop/src/db/settings-migrations/v10.ts
+++ b/apps/desktop/src/db/settings-migrations/v10.ts
@@ -1,6 +1,6 @@
 import type { AppSettingsData } from "../schema";
 
-// v9 -> v10: add keepTranscriptInClipboard preference
+// v9 -> v10: add preserveClipboard preference
 export function migrateToV10(data: unknown): AppSettingsData {
   const oldData = data as AppSettingsData;
   const preferences = oldData.preferences ?? {};
@@ -9,7 +9,7 @@ export function migrateToV10(data: unknown): AppSettingsData {
     ...oldData,
     preferences: {
       ...preferences,
-      keepTranscriptInClipboard: false,
+      preserveClipboard: true,
     },
   };
 }

--- a/apps/desktop/src/i18n/locales/en.json
+++ b/apps/desktop/src/i18n/locales/en.json
@@ -450,6 +450,10 @@
         "label": "Preload Whisper Model",
         "description": "Load AI model at startup for faster transcription"
       },
+      "keepTranscriptInClipboard": {
+        "label": "Keep transcript in clipboard",
+        "description": "Leave transcribed text on your clipboard after pasting instead of restoring previous contents"
+      },
       "debugMode": {
         "label": "Debug Mode",
         "description": "Enable detailed logging"

--- a/apps/desktop/src/i18n/locales/en.json
+++ b/apps/desktop/src/i18n/locales/en.json
@@ -450,9 +450,9 @@
         "label": "Preload Whisper Model",
         "description": "Load AI model at startup for faster transcription"
       },
-      "keepTranscriptInClipboard": {
-        "label": "Keep transcript in clipboard",
-        "description": "Leave transcribed text on your clipboard after pasting instead of restoring previous contents"
+      "preserveClipboard": {
+        "label": "Preserve clipboard contents",
+        "description": "After pasting a transcript, restore whatever was previously on your clipboard."
       },
       "debugMode": {
         "label": "Debug Mode",

--- a/apps/desktop/src/i18n/locales/es.json
+++ b/apps/desktop/src/i18n/locales/es.json
@@ -450,9 +450,9 @@
         "label": "Precargar modelo Whisper",
         "description": "Cargar el modelo de IA al iniciar para una transcripción más rápida"
       },
-      "keepTranscriptInClipboard": {
-        "label": "Mantener transcripción en el portapapeles",
-        "description": "Dejar el texto transcrito en el portapapeles después de pegar en lugar de restaurar el contenido anterior"
+      "preserveClipboard": {
+        "label": "Conservar el contenido del portapapeles",
+        "description": "Después de pegar una transcripción, restaura lo que antes estaba en el portapapeles."
       },
       "debugMode": {
         "label": "Modo de depuración",

--- a/apps/desktop/src/i18n/locales/es.json
+++ b/apps/desktop/src/i18n/locales/es.json
@@ -450,6 +450,10 @@
         "label": "Precargar modelo Whisper",
         "description": "Cargar el modelo de IA al iniciar para una transcripción más rápida"
       },
+      "keepTranscriptInClipboard": {
+        "label": "Mantener transcripción en el portapapeles",
+        "description": "Dejar el texto transcrito en el portapapeles después de pegar en lugar de restaurar el contenido anterior"
+      },
       "debugMode": {
         "label": "Modo de depuración",
         "description": "Habilitar registro detallado"

--- a/apps/desktop/src/i18n/locales/ja.json
+++ b/apps/desktop/src/i18n/locales/ja.json
@@ -450,6 +450,10 @@
         "label": "Whisperモデルをプリロード",
         "description": "起動時にAIモデルを読み込み、文字起こしを高速化"
       },
+      "keepTranscriptInClipboard": {
+        "label": "文字起こしをクリップボードに保持",
+        "description": "貼り付け後にクリップボードの元の内容を復元せず、文字起こしテキストをクリップボードに残します"
+      },
       "debugMode": {
         "label": "デバッグモード",
         "description": "詳細なログを有効にする"

--- a/apps/desktop/src/i18n/locales/ja.json
+++ b/apps/desktop/src/i18n/locales/ja.json
@@ -450,9 +450,9 @@
         "label": "Whisperモデルをプリロード",
         "description": "起動時にAIモデルを読み込み、文字起こしを高速化"
       },
-      "keepTranscriptInClipboard": {
-        "label": "文字起こしをクリップボードに保持",
-        "description": "貼り付け後にクリップボードの元の内容を復元せず、文字起こしテキストをクリップボードに残します"
+      "preserveClipboard": {
+        "label": "クリップボードの内容を保持",
+        "description": "文字起こしを貼り付けた後、もともとクリップボードにあった内容を復元します。"
       },
       "debugMode": {
         "label": "デバッグモード",

--- a/apps/desktop/src/i18n/locales/zh-TW.json
+++ b/apps/desktop/src/i18n/locales/zh-TW.json
@@ -450,6 +450,10 @@
         "label": "預載 Whisper 模型",
         "description": "啟動時載入 AI 模型以獲得更快的轉錄速度"
       },
+      "preserveClipboard": {
+        "label": "保留原有剪貼簿內容",
+        "description": "貼上轉錄內容後，恢復先前在剪貼簿中的內容。"
+      },
       "debugMode": {
         "label": "除錯模式",
         "description": "啟用詳細紀錄的功能"

--- a/apps/desktop/src/main/managers/recording-manager.ts
+++ b/apps/desktop/src/main/managers/recording-manager.ts
@@ -887,22 +887,20 @@ export class RecordingManager extends EventEmitter {
 
     try {
       const nativeBridge = this.serviceManager.getService("nativeBridge");
-      const settingsService =
-        this.serviceManager.getService("settingsService");
+      const settingsService = this.serviceManager.getService("settingsService");
       const preferences = await settingsService.getPreferences();
-      const keepInClipboard =
-        preferences?.keepTranscriptInClipboard ?? false;
+      const preserveClipboard = preferences?.preserveClipboard ?? true;
 
       logger.main.info("Pasting transcription to active application", {
         textLength: transcription.length,
-        keepInClipboard,
+        preserveClipboard,
       });
 
       if (nativeBridge) {
         void nativeBridge
           .call("pasteText", {
             transcript: transcription,
-            keepInClipboard,
+            preserveClipboard,
           })
           .catch((error) => {
             logger.main.warn(

--- a/apps/desktop/src/main/managers/recording-manager.ts
+++ b/apps/desktop/src/main/managers/recording-manager.ts
@@ -887,15 +887,22 @@ export class RecordingManager extends EventEmitter {
 
     try {
       const nativeBridge = this.serviceManager.getService("nativeBridge");
+      const settingsService =
+        this.serviceManager.getService("settingsService");
+      const preferences = await settingsService.getPreferences();
+      const keepInClipboard =
+        preferences?.keepTranscriptInClipboard ?? false;
 
       logger.main.info("Pasting transcription to active application", {
         textLength: transcription.length,
+        keepInClipboard,
       });
 
       if (nativeBridge) {
         void nativeBridge
           .call("pasteText", {
             transcript: transcription,
+            keepInClipboard,
           })
           .catch((error) => {
             logger.main.warn(

--- a/apps/desktop/src/renderer/main/pages/settings/advanced/index.tsx
+++ b/apps/desktop/src/renderer/main/pages/settings/advanced/index.tsx
@@ -68,6 +68,7 @@ export default function AdvancedSettingsPage() {
       },
       onError: (error) => {
         console.error("Failed to update preferences:", error);
+        utils.settings.getPreferences.invalidate();
         toast.error(t("settings.advanced.toast.settingsUpdateFailed"));
       },
     });

--- a/apps/desktop/src/renderer/main/pages/settings/advanced/index.tsx
+++ b/apps/desktop/src/renderer/main/pages/settings/advanced/index.tsx
@@ -35,8 +35,7 @@ import { useTranslation } from "react-i18next";
 export default function AdvancedSettingsPage() {
   const { t } = useTranslation();
   const [preloadWhisperModel, setPreloadWhisperModel] = useState(true);
-  const [keepTranscriptInClipboard, setKeepTranscriptInClipboard] =
-    useState(false);
+  const [preserveClipboard, setPreserveClipboard] = useState(true);
   const [isResetting, setIsResetting] = useState(false);
 
   // tRPC queries and mutations
@@ -60,18 +59,17 @@ export default function AdvancedSettingsPage() {
       },
     });
 
-  const updatePreferencesMutation =
-    api.settings.updatePreferences.useMutation({
-      onSuccess: () => {
-        utils.settings.getPreferences.invalidate();
-        toast.success(t("settings.advanced.toast.settingsUpdated"));
-      },
-      onError: (error) => {
-        console.error("Failed to update preferences:", error);
-        utils.settings.getPreferences.invalidate();
-        toast.error(t("settings.advanced.toast.settingsUpdateFailed"));
-      },
-    });
+  const updatePreferencesMutation = api.settings.updatePreferences.useMutation({
+    onSuccess: () => {
+      utils.settings.getPreferences.invalidate();
+      toast.success(t("settings.advanced.toast.settingsUpdated"));
+    },
+    onError: (error) => {
+      console.error("Failed to update preferences:", error);
+      utils.settings.getPreferences.invalidate();
+      toast.error(t("settings.advanced.toast.settingsUpdateFailed"));
+    },
+  });
 
   const updateTelemetrySettingsMutation =
     api.settings.updateTelemetrySettings.useMutation({
@@ -134,9 +132,7 @@ export default function AdvancedSettingsPage() {
 
   useEffect(() => {
     if (preferencesQuery.data) {
-      setKeepTranscriptInClipboard(
-        preferencesQuery.data.keepTranscriptInClipboard ?? false,
-      );
+      setPreserveClipboard(preferencesQuery.data.preserveClipboard ?? true);
     }
   }, [preferencesQuery.data]);
 
@@ -147,10 +143,10 @@ export default function AdvancedSettingsPage() {
     });
   };
 
-  const handleKeepTranscriptInClipboardChange = (checked: boolean) => {
-    setKeepTranscriptInClipboard(checked);
+  const handlePreserveClipboardChange = (checked: boolean) => {
+    setPreserveClipboard(checked);
     updatePreferencesMutation.mutate({
-      keepTranscriptInClipboard: checked,
+      preserveClipboard: checked,
     });
   };
 
@@ -205,19 +201,17 @@ export default function AdvancedSettingsPage() {
 
           <div className="flex items-center justify-between">
             <div>
-              <Label htmlFor="keep-transcript-clipboard">
-                {t("settings.advanced.keepTranscriptInClipboard.label")}
+              <Label htmlFor="preserve-clipboard">
+                {t("settings.advanced.preserveClipboard.label")}
               </Label>
               <p className="text-sm text-muted-foreground">
-                {t(
-                  "settings.advanced.keepTranscriptInClipboard.description",
-                )}
+                {t("settings.advanced.preserveClipboard.description")}
               </p>
             </div>
             <Switch
-              id="keep-transcript-clipboard"
-              checked={keepTranscriptInClipboard}
-              onCheckedChange={handleKeepTranscriptInClipboardChange}
+              id="preserve-clipboard"
+              checked={preserveClipboard}
+              onCheckedChange={handlePreserveClipboardChange}
             />
           </div>
 

--- a/apps/desktop/src/services/settings-service.ts
+++ b/apps/desktop/src/services/settings-service.ts
@@ -31,7 +31,7 @@ export interface AppPreferences {
   muteSystemAudio: boolean;
   muteDictationSounds: boolean;
   autoDictateOnNewNote: boolean;
-  keepTranscriptInClipboard: boolean;
+  preserveClipboard: boolean;
 }
 
 export class SettingsService extends EventEmitter {
@@ -345,7 +345,7 @@ export class SettingsService extends EventEmitter {
       muteSystemAudio: preferences?.muteSystemAudio ?? true,
       muteDictationSounds: preferences?.muteDictationSounds ?? false,
       autoDictateOnNewNote: preferences?.autoDictateOnNewNote ?? false,
-      keepTranscriptInClipboard: preferences?.keepTranscriptInClipboard ?? false,
+      preserveClipboard: preferences?.preserveClipboard ?? true,
     };
   }
 

--- a/apps/desktop/src/services/settings-service.ts
+++ b/apps/desktop/src/services/settings-service.ts
@@ -31,6 +31,7 @@ export interface AppPreferences {
   muteSystemAudio: boolean;
   muteDictationSounds: boolean;
   autoDictateOnNewNote: boolean;
+  keepTranscriptInClipboard: boolean;
 }
 
 export class SettingsService extends EventEmitter {
@@ -344,6 +345,7 @@ export class SettingsService extends EventEmitter {
       muteSystemAudio: preferences?.muteSystemAudio ?? true,
       muteDictationSounds: preferences?.muteDictationSounds ?? false,
       autoDictateOnNewNote: preferences?.autoDictateOnNewNote ?? false,
+      keepTranscriptInClipboard: preferences?.keepTranscriptInClipboard ?? false,
     };
   }
 

--- a/apps/desktop/src/trpc/routers/settings.ts
+++ b/apps/desktop/src/trpc/routers/settings.ts
@@ -64,7 +64,7 @@ const AppPreferencesSchema = z.object({
   muteSystemAudio: z.boolean().optional(),
   muteDictationSounds: z.boolean().optional(),
   autoDictateOnNewNote: z.boolean().optional(),
-  keepTranscriptInClipboard: z.boolean().optional(),
+  preserveClipboard: z.boolean().optional(),
 });
 
 const UIThemeSchema = z.object({

--- a/apps/desktop/src/trpc/routers/settings.ts
+++ b/apps/desktop/src/trpc/routers/settings.ts
@@ -64,6 +64,7 @@ const AppPreferencesSchema = z.object({
   muteSystemAudio: z.boolean().optional(),
   muteDictationSounds: z.boolean().optional(),
   autoDictateOnNewNote: z.boolean().optional(),
+  keepTranscriptInClipboard: z.boolean().optional(),
 });
 
 const UIThemeSchema = z.object({

--- a/packages/native-helpers/swift-helper/Sources/SwiftHelper/AccessibilityService.swift
+++ b/packages/native-helpers/swift-helper/Sources/SwiftHelper/AccessibilityService.swift
@@ -447,7 +447,7 @@ class AccessibilityService {
     }
 
     // Pastes the given text into the active application
-    public func pasteText(transcript: String) -> Bool {
+    public func pasteText(transcript: String, keepInClipboard: Bool = false) -> Bool {
         logToStderr("[AccessibilityService] Attempting to paste transcript: \(transcript).")
 
         let pasteboard = NSPasteboard.general
@@ -512,10 +512,14 @@ class AccessibilityService {
 
         // Restore the original pasteboard content after a short delay
         // to allow the paste action to complete.
-        DispatchQueue.main.asyncAfter(deadline: .now() + PASTE_RESTORE_DELAY_SECONDS) {
-            self.restorePasteboard(
-                pasteboard: pasteboard, items: originalPasteboardItems,
-                originalChangeCount: originalChangeCount)
+        if keepInClipboard {
+            logToStderr("[AccessibilityService] keepInClipboard=true, skipping pasteboard restoration.")
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + PASTE_RESTORE_DELAY_SECONDS) {
+                self.restorePasteboard(
+                    pasteboard: pasteboard, items: originalPasteboardItems,
+                    originalChangeCount: originalChangeCount)
+            }
         }
 
         return true

--- a/packages/native-helpers/swift-helper/Sources/SwiftHelper/AccessibilityService.swift
+++ b/packages/native-helpers/swift-helper/Sources/SwiftHelper/AccessibilityService.swift
@@ -447,7 +447,7 @@ class AccessibilityService {
     }
 
     // Pastes the given text into the active application
-    public func pasteText(transcript: String, keepInClipboard: Bool = false) -> Bool {
+    public func pasteText(transcript: String, preserveClipboard: Bool = true) -> Bool {
         logToStderr("[AccessibilityService] Attempting to paste transcript: \(transcript).")
 
         let pasteboard = NSPasteboard.general
@@ -512,14 +512,14 @@ class AccessibilityService {
 
         // Restore the original pasteboard content after a short delay
         // to allow the paste action to complete.
-        if keepInClipboard {
-            logToStderr("[AccessibilityService] keepInClipboard=true, skipping pasteboard restoration.")
-        } else {
+        if preserveClipboard {
             DispatchQueue.main.asyncAfter(deadline: .now() + PASTE_RESTORE_DELAY_SECONDS) {
                 self.restorePasteboard(
                     pasteboard: pasteboard, items: originalPasteboardItems,
                     originalChangeCount: originalChangeCount)
             }
+        } else {
+            logToStderr("[AccessibilityService] preserveClipboard=false, skipping pasteboard restoration.")
         }
 
         return true

--- a/packages/native-helpers/swift-helper/Sources/SwiftHelper/RpcHandler.swift
+++ b/packages/native-helpers/swift-helper/Sources/SwiftHelper/RpcHandler.swift
@@ -73,7 +73,8 @@ class IOBridge: NSObject {
                 logToStderr("[IOBridge] Decoded pasteParams.transcript for ID: \(request.id)")
 
                 // Call the actual paste function (to be implemented in AccessibilityService or similar)
-                let success = accessibilityService.pasteText(transcript: pasteParams.transcript)
+                let keepInClipboard = pasteParams.keepInClipboard ?? false
+                let success = accessibilityService.pasteText(transcript: pasteParams.transcript, keepInClipboard: keepInClipboard)
 
                 // Corrected to use generated Swift model name from models.swift
                 let resultPayload = PasteTextResultSchema(

--- a/packages/native-helpers/swift-helper/Sources/SwiftHelper/RpcHandler.swift
+++ b/packages/native-helpers/swift-helper/Sources/SwiftHelper/RpcHandler.swift
@@ -73,8 +73,8 @@ class IOBridge: NSObject {
                 logToStderr("[IOBridge] Decoded pasteParams.transcript for ID: \(request.id)")
 
                 // Call the actual paste function (to be implemented in AccessibilityService or similar)
-                let keepInClipboard = pasteParams.keepInClipboard ?? false
-                let success = accessibilityService.pasteText(transcript: pasteParams.transcript, keepInClipboard: keepInClipboard)
+                let preserveClipboard = pasteParams.preserveClipboard ?? true
+                let success = accessibilityService.pasteText(transcript: pasteParams.transcript, preserveClipboard: preserveClipboard)
 
                 // Corrected to use generated Swift model name from models.swift
                 let resultPayload = PasteTextResultSchema(

--- a/packages/native-helpers/windows-helper/src/Models/Generated/Models.cs
+++ b/packages/native-helpers/windows-helper/src/Models/Generated/Models.cs
@@ -261,6 +261,10 @@ namespace WindowsHelper.Models
 
     public partial class PasteTextParams
     {
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("keepInClipboard")]
+        public bool? KeepInClipboard { get; set; }
+
         [JsonPropertyName("transcript")]
         public string Transcript { get; set; }
     }

--- a/packages/native-helpers/windows-helper/src/Models/Generated/Models.cs
+++ b/packages/native-helpers/windows-helper/src/Models/Generated/Models.cs
@@ -262,8 +262,8 @@ namespace WindowsHelper.Models
     public partial class PasteTextParams
     {
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        [JsonPropertyName("keepInClipboard")]
-        public bool? KeepInClipboard { get; set; }
+        [JsonPropertyName("preserveClipboard")]
+        public bool? PreserveClipboard { get; set; }
 
         [JsonPropertyName("transcript")]
         public string Transcript { get; set; }

--- a/packages/native-helpers/windows-helper/src/RpcHandler.cs
+++ b/packages/native-helpers/windows-helper/src/RpcHandler.cs
@@ -314,7 +314,7 @@ namespace WindowsHelper
                         Result = new PasteTextResult
                         {
                             Success = success,
-                            Message = success ? "Pasted successfully" : (errorMessage ?? "Paste failed")
+                            Message = success ? (errorMessage ?? "Pasted successfully") : (errorMessage ?? "Paste failed")
                         }
                     };
                 }

--- a/packages/native-helpers/windows-helper/src/RpcHandler.cs
+++ b/packages/native-helpers/windows-helper/src/RpcHandler.cs
@@ -306,7 +306,8 @@ namespace WindowsHelper
 
                 if (parameters != null)
                 {
-                    var success = accessibilityService.PasteText(parameters.Transcript, out var errorMessage);
+                    var keepInClipboard = parameters.KeepInClipboard ?? false;
+                    var success = accessibilityService.PasteText(parameters.Transcript, keepInClipboard, out var errorMessage);
                     return new RpcResponse
                     {
                         Id = request.Id.ToString(),

--- a/packages/native-helpers/windows-helper/src/RpcHandler.cs
+++ b/packages/native-helpers/windows-helper/src/RpcHandler.cs
@@ -306,8 +306,8 @@ namespace WindowsHelper
 
                 if (parameters != null)
                 {
-                    var keepInClipboard = parameters.KeepInClipboard ?? false;
-                    var success = accessibilityService.PasteText(parameters.Transcript, keepInClipboard, out var errorMessage);
+                    var preserveClipboard = parameters.PreserveClipboard ?? true;
+                    var success = accessibilityService.PasteText(parameters.Transcript, preserveClipboard, out var errorMessage);
                     return new RpcResponse
                     {
                         Id = request.Id.ToString(),

--- a/packages/native-helpers/windows-helper/src/Services/AccessibilityService.cs
+++ b/packages/native-helpers/windows-helper/src/Services/AccessibilityService.cs
@@ -35,13 +35,13 @@ namespace WindowsHelper.Services
             return AccessibilityContextService.GetAccessibilityContext(editableOnly);
         }
 
-        public bool PasteText(string text, bool keepInClipboard, out string? errorMessage)
+        public bool PasteText(string text, bool preserveClipboard, out string? errorMessage)
         {
             errorMessage = null;
 
             try
             {
-                LogToStderr($"PasteText called with text length: {text.Length}, keepInClipboard: {keepInClipboard}");
+                LogToStderr($"PasteText called with text length: {text.Length}, preserveClipboard: {preserveClipboard}");
 
                 // Save original clipboard content
                 var savedContent = clipboardService.Save();
@@ -67,11 +67,7 @@ namespace WindowsHelper.Services
                 // Wait for paste to complete before restoring
                 Thread.Sleep(200);
 
-                if (keepInClipboard)
-                {
-                    LogToStderr("keepInClipboard=true, skipping clipboard restoration.");
-                }
-                else
+                if (preserveClipboard)
                 {
                     // Restore original clipboard synchronously and report errors
                     var restoreError = clipboardService.RestoreSync(savedContent, newSeq);
@@ -82,6 +78,10 @@ namespace WindowsHelper.Services
                         LogToStderr(errorMessage);
                         // Still return true since the paste itself worked
                     }
+                }
+                else
+                {
+                    LogToStderr("preserveClipboard=false, skipping clipboard restoration.");
                 }
 
                 return true;

--- a/packages/types/src/schemas/methods/paste-text.ts
+++ b/packages/types/src/schemas/methods/paste-text.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 // Request params
 export const PasteTextParamsSchema = z.object({
   transcript: z.string(),
+  keepInClipboard: z.boolean().optional(),
 });
 export type PasteTextParams = z.infer<typeof PasteTextParamsSchema>;
 

--- a/packages/types/src/schemas/methods/paste-text.ts
+++ b/packages/types/src/schemas/methods/paste-text.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 // Request params
 export const PasteTextParamsSchema = z.object({
   transcript: z.string(),
-  keepInClipboard: z.boolean().optional(),
+  preserveClipboard: z.boolean().optional(),
 });
 export type PasteTextParams = z.infer<typeof PasteTextParamsSchema>;
 


### PR DESCRIPTION
Add a "Keep transcript in clipboard" toggle to Advanced Settings that skips restoring the original clipboard contents after dictation paste, leaving the transcribed text available for subsequent manual pastes.

Addresses issue #100.

<img width="1312" height="912" alt="image" src="https://github.com/user-attachments/assets/52d57416-4734-4b66-ade4-735a376c0169" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Keep Transcript in Clipboard" toggle in Advanced Preferences (off by default). When enabled, pasted transcriptions remain in the clipboard instead of restoring prior contents; behavior applies across supported platforms.

* **Localization**
  * UI label and description added for English, Spanish, and Japanese.

* **Chores**
  * Settings updated so existing users receive the new preference with a default value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->