### PR TITLE
fix(desktop): make error toast dismissable

### DIFF
--- a/apps/desktop/src/i18n/locales/en.json
+++ b/apps/desktop/src/i18n/locales/en.json
@@ -245,6 +245,7 @@
       "discordAlt": "Discord",
       "copyErrorId": "Copy Error ID",
       "recordingSaved": "Your recording is saved. You can access it in History.",
+      "dismiss": "Dismiss notification",
       "description": {
         "noAudio": "No audio from \"{{microphone}}\"",
         "emptyTranscript": "No speech detected from \"{{microphone}}\"",

--- a/apps/desktop/src/i18n/locales/es.json
+++ b/apps/desktop/src/i18n/locales/es.json
@@ -245,6 +245,7 @@
       "discordAlt": "Discord",
       "copyErrorId": "Copiar ID de error",
       "recordingSaved": "Tu grabación fue guardada. Puedes acceder a ella en el Historial.",
+      "dismiss": "Descartar notificación",
       "description": {
         "noAudio": "Sin audio de \"{{microphone}}\"",
         "emptyTranscript": "No se detectó voz de \"{{microphone}}\"",

--- a/apps/desktop/src/i18n/locales/ja.json
+++ b/apps/desktop/src/i18n/locales/ja.json
@@ -245,6 +245,7 @@
       "discordAlt": "Discord",
       "copyErrorId": "エラーIDをコピー",
       "recordingSaved": "録音が保存されました。履歴からアクセスできます。",
+      "dismiss": "通知を閉じる",
       "description": {
         "noAudio": "「{{microphone}}」からの音声がありません",
         "emptyTranscript": "「{{microphone}}」から音声が検出されませんでした",

--- a/apps/desktop/src/renderer/widget/components/ToasterWrapper.tsx
+++ b/apps/desktop/src/renderer/widget/components/ToasterWrapper.tsx
@@ -1,44 +1,13 @@
-import React, { useRef } from "react";
+import React from "react";
 import { Toaster } from "@/components/ui/sonner";
-import { api } from "@/trpc/react";
-
-const DEBOUNCE_DELAY = 100;
 
 /**
- * Wrapper for Toaster that handles mouse events to enable/disable
- * pass-through on the widget window, making toasts clickable.
+ * Pure positioning wrapper for widget toasts.
+ * Pass-through is managed in notification lifecycle to avoid hover races.
  */
 export const ToasterWrapper: React.FC = () => {
-  const setIgnoreMouseEvents = api.widget.setIgnoreMouseEvents.useMutation();
-  const leaveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  const handleMouseEnter = async () => {
-    console.log("ToasterWrapper: mouse enter");
-    if (leaveTimeoutRef.current) {
-      clearTimeout(leaveTimeoutRef.current);
-      leaveTimeoutRef.current = null;
-    }
-    // Disable pass-through to make toast clickable
-    await setIgnoreMouseEvents.mutateAsync({ ignore: false });
-    console.log("ToasterWrapper: pass-through disabled");
-  };
-
-  const handleMouseLeave = () => {
-    console.log("ToasterWrapper: mouse leave");
-    if (leaveTimeoutRef.current) {
-      clearTimeout(leaveTimeoutRef.current);
-    }
-    leaveTimeoutRef.current = setTimeout(async () => {
-      // Re-enable pass-through
-      await setIgnoreMouseEvents.mutateAsync({ ignore: true });
-      console.log("ToasterWrapper: pass-through re-enabled");
-    }, DEBOUNCE_DELAY);
-  };
-
   return (
     <div
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
       style={{
         position: "fixed",
         bottom: 0,

--- a/apps/desktop/src/renderer/widget/components/WidgetToast.tsx
+++ b/apps/desktop/src/renderer/widget/components/WidgetToast.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { XIcon } from "lucide-react";
 import type {
   LocalizedText,
   WidgetNotificationAction,
@@ -22,6 +23,7 @@ interface WidgetToastProps {
   primaryAction?: WidgetNotificationAction;
   secondaryAction?: WidgetNotificationAction;
   onActionClick: (action: WidgetNotificationAction) => void;
+  onDismiss: () => void;
 }
 
 export const WidgetToast: React.FC<WidgetToastProps> = ({
@@ -33,6 +35,7 @@ export const WidgetToast: React.FC<WidgetToastProps> = ({
   primaryAction,
   secondaryAction,
   onActionClick,
+  onDismiss,
 }) => {
   const { t } = useTranslation();
 
@@ -48,7 +51,15 @@ export const WidgetToast: React.FC<WidgetToastProps> = ({
   };
 
   return (
-    <Card className="min-w-[300px] gap-3 py-4 shadow-lg">
+    <Card className="relative min-w-[300px] gap-3 py-4 shadow-lg">
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label={t("widget.notifications.dismiss")}
+        className="text-muted-foreground hover:text-foreground absolute top-1 right-1 flex size-8 items-center justify-center rounded-md opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden"
+      >
+        <XIcon className="size-4" />
+      </button>
       <CardHeader className="gap-1 px-4 py-0 text-center">
         <CardTitle className={`text-sm ${isError ? "text-destructive" : ""}`}>
           {resolveText(title)}

--- a/apps/desktop/src/renderer/widget/hooks/useWidgetNotifications.tsx
+++ b/apps/desktop/src/renderer/widget/hooks/useWidgetNotifications.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { api } from "@/trpc/react";
 import { useAudioDevices } from "@/hooks/useAudioDevices";
@@ -5,9 +6,12 @@ import {
   WIDGET_NOTIFICATION_TIMEOUT,
   getNotificationDescription,
   type WidgetNotificationAction,
+  type WidgetNotification,
 } from "@/types/widget-notification";
 import { WidgetToast } from "../components/WidgetToast";
 import { useTranslation } from "react-i18next";
+
+const TOAST_INTERACTION_STATE_EVENT = "widget:toast-interaction-state";
 
 export const useWidgetNotifications = () => {
   const { t } = useTranslation();
@@ -15,16 +19,21 @@ export const useWidgetNotifications = () => {
   const setIgnoreMouseEvents = api.widget.setIgnoreMouseEvents.useMutation();
   const { data: settings } = api.settings.getSettings.useQuery();
   const { defaultDeviceName } = useAudioDevices();
+  const activeToastIdsRef = useRef<Set<string | number>>(new Set());
 
   // Get effective mic name: preferred from settings, or system default
   const getEffectiveMicName = () => {
     return settings?.recording?.preferredMicrophoneName || defaultDeviceName;
   };
 
-  const reEnablePassThrough = () => {
-    setTimeout(() => {
-      setIgnoreMouseEvents.mutate({ ignore: true });
-    }, 100);
+  const syncPassThroughWithToastState = () => {
+    const hasActiveToasts = activeToastIdsRef.current.size > 0;
+    setIgnoreMouseEvents.mutate({ ignore: !hasActiveToasts });
+    window.dispatchEvent(
+      new CustomEvent<{ active: boolean }>(TOAST_INTERACTION_STATE_EVENT, {
+        detail: { active: hasActiveToasts },
+      }),
+    );
   };
 
   const handleActionClick = async (action: WidgetNotificationAction) => {
@@ -33,44 +42,72 @@ export const useWidgetNotifications = () => {
     } else if (action.externalUrl) {
       await window.electronAPI.openExternal(action.externalUrl);
     }
-    reEnablePassThrough();
   };
+
+  const showNotificationToast = (
+    notification: Pick<
+      WidgetNotification,
+      | "type"
+      | "title"
+      | "description"
+      | "traceId"
+      | "primaryAction"
+      | "secondaryAction"
+    >,
+    duration = WIDGET_NOTIFICATION_TIMEOUT,
+  ) => {
+    const micName = getEffectiveMicName() || t("widget.notifications.micFallback");
+    const description =
+      notification.description ||
+      getNotificationDescription(notification.type, micName);
+
+    const createdToastId = toast.custom(
+      (toastId) => (
+        <WidgetToast
+          title={notification.title}
+          description={description}
+          isError={true}
+          showRecordingSaved={
+            notification.type === "transcription_failed" ||
+            notification.type === "empty_transcript"
+          }
+          traceId={notification.traceId}
+          primaryAction={notification.primaryAction}
+          secondaryAction={notification.secondaryAction}
+          onActionClick={(action) => {
+            handleActionClick(action);
+            toast.dismiss(toastId);
+          }}
+          onDismiss={() => toast.dismiss(toastId)}
+        />
+      ),
+      {
+        unstyled: true,
+        duration,
+        onDismiss: () => {
+          activeToastIdsRef.current.delete(createdToastId);
+          syncPassThroughWithToastState();
+        },
+        onAutoClose: () => {
+          activeToastIdsRef.current.delete(createdToastId);
+          syncPassThroughWithToastState();
+        },
+      },
+    );
+    activeToastIdsRef.current.add(createdToastId);
+    syncPassThroughWithToastState();
+  };
+
+  useEffect(() => {
+    return () => {
+      activeToastIdsRef.current.clear();
+      setIgnoreMouseEvents.mutate({ ignore: true });
+    };
+  }, []);
 
   api.recording.widgetNotifications.useSubscription(undefined, {
     onData: (notification) => {
-      // Use provided description, or generate with mic name for audio-related notifications
-      const micName =
-        getEffectiveMicName() || t("widget.notifications.micFallback");
-      const description =
-        notification.description ||
-        getNotificationDescription(notification.type, micName);
-
-      toast.custom(
-        (toastId) => (
-          <WidgetToast
-            title={notification.title}
-            description={description}
-            isError={true}
-            showRecordingSaved={
-              notification.type === "transcription_failed" ||
-              notification.type === "empty_transcript"
-            }
-            traceId={notification.traceId}
-            primaryAction={notification.primaryAction}
-            secondaryAction={notification.secondaryAction}
-            onActionClick={(action) => {
-              handleActionClick(action);
-              toast.dismiss(toastId);
-            }}
-          />
-        ),
-        {
-          unstyled: true,
-          duration: WIDGET_NOTIFICATION_TIMEOUT,
-          onDismiss: reEnablePassThrough,
-          onAutoClose: reEnablePassThrough,
-        },
-      );
+      showNotificationToast(notification);
     },
     onError: (error) => {
       console.error("Widget notification subscription error:", error);

--- a/apps/desktop/src/renderer/widget/pages/widget/components/FloatingButton.tsx
+++ b/apps/desktop/src/renderer/widget/pages/widget/components/FloatingButton.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next";
 
 const NUM_WAVEFORM_BARS = 6; // Fewer bars to make room for stop button
 const DEBOUNCE_DELAY = 100; // milliseconds
+const TOAST_INTERACTION_STATE_EVENT = "widget:toast-interaction-state";
 
 // Separate component for the stop button
 const StopButton: React.FC<{ onClick: (e: React.MouseEvent) => void }> = ({
@@ -56,6 +57,7 @@ export const FloatingButton: React.FC = () => {
   const [isHovered, setIsHovered] = useState(false);
   const leaveTimeoutRef = useRef<NodeJS.Timeout | null>(null); // Ref for debounce timeout
   const clickTimeRef = useRef<number | null>(null); // Track when user clicked
+  const hasActiveToastRef = useRef(false);
 
   // tRPC mutation to control widget mouse events
   const setIgnoreMouseEvents = api.widget.setIgnoreMouseEvents.useMutation();
@@ -65,7 +67,22 @@ export const FloatingButton: React.FC = () => {
   // Log component initialization
   useEffect(() => {
     console.log("FloatingButton component initialized");
+
+    const handleToastInteractionState = (event: Event) => {
+      const customEvent = event as CustomEvent<{ active: boolean }>;
+      hasActiveToastRef.current = !!customEvent.detail?.active;
+    };
+
+    window.addEventListener(
+      TOAST_INTERACTION_STATE_EVENT,
+      handleToastInteractionState,
+    );
+
     return () => {
+      window.removeEventListener(
+        TOAST_INTERACTION_STATE_EVENT,
+        handleToastInteractionState,
+      );
       console.debug("FloatingButton component unmounting");
     };
   }, []);
@@ -99,7 +116,6 @@ export const FloatingButton: React.FC = () => {
     console.log("FAB: Button clicked at", clickTime);
     console.log("FAB: Current status:", recordingStatus);
 
-    // Only start recording if not already recording
     if (recordingStatus.state === "idle") {
       const startRecordingCallTime = performance.now();
       await startRecording();
@@ -142,6 +158,12 @@ export const FloatingButton: React.FC = () => {
     }
     leaveTimeoutRef.current = setTimeout(async () => {
       setIsHovered(false);
+      if (hasActiveToastRef.current) {
+        console.debug(
+          "Skipped re-enabling mouse pass-through while toast is active",
+        );
+        return;
+      }
       // Re-enable mouse event forwarding when not hovering
       try {
         await setIgnoreMouseEvents.mutateAsync({ ignore: true });


### PR DESCRIPTION
## Summary\n- add a dismiss (X) button to widget error toasts with a larger hit target\n- add localized dismiss aria-label text for en/es/ja\n- stabilize widget toast interaction by coordinating mouse pass-through with active toast lifecycle\n\n## Validation\n- pnpm -C apps/desktop exec eslint src/renderer/widget/components/WidgetToast.tsx src/renderer/widget/components/ToasterWrapper.tsx src/renderer/widget/hooks/useWidgetNotifications.tsx src/renderer/widget/pages/widget/components/FloatingButton.tsx\n- pnpm -C apps/desktop type:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dismiss button to notifications, allowing users to manually close notifications at any time.

* **Internationalization**
  * Added "dismiss" notification label translations in English, Spanish, and Japanese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->