### PR TITLE
fix: increase recording window to allow longer clips

### DIFF
--- a/apps/desktop/src/pipeline/providers/transcription/amical-cloud-provider.ts
+++ b/apps/desktop/src/pipeline/providers/transcription/amical-cloud-provider.ts
@@ -58,7 +58,7 @@ export class AmicalCloudProvider implements TranscriptionProvider {
   // Configuration
   private readonly FRAME_SIZE = 512; // 32ms at 16kHz
   private readonly MIN_AUDIO_DURATION_MS = 500; // Minimum buffered audio duration before silence-based transcription
-  private readonly MAX_SILENCE_DURATION_MS = 3000; // Max silence before cutting
+  private readonly MAX_SILENCE_DURATION_MS = 10000; // Max silence before cutting (10 seconds for longer recording windows)
   private readonly SAMPLE_RATE = 16000;
   private readonly SPEECH_PROBABILITY_THRESHOLD = 0.2;
 

--- a/apps/desktop/src/pipeline/providers/transcription/whisper-provider.ts
+++ b/apps/desktop/src/pipeline/providers/transcription/whisper-provider.ts
@@ -44,7 +44,7 @@ export class WhisperProvider implements TranscriptionProvider {
   // Configuration
   private readonly FRAME_SIZE = 512; // 32ms at 16kHz
   private readonly MIN_AUDIO_DURATION_MS = 500; // Minimum buffered audio duration before silence-based transcription
-  private readonly MAX_SILENCE_DURATION_MS = 3000; // Max silence before cutting
+  private readonly MAX_SILENCE_DURATION_MS = 10000; // Max silence before cutting (10 seconds for longer recording windows)
   private readonly SAMPLE_RATE = 16000;
   private readonly SPEECH_PROBABILITY_THRESHOLD = 0.2; // Threshold for speech detection
 


### PR DESCRIPTION
Fixes #113

The recording was stopping after ~8 seconds because the silence detection
threshold (MAX_SILENCE_DURATION_MS) was set to only 3 seconds. When users
speak with natural pauses between sentences, the transcription would
trigger and clear the audio buffer, making it appear as if the recording
stopped abruptly.

This fix increases the silence threshold from 3 seconds to 10 seconds,
allowing users to record longer clips with natural speech patterns including
pauses between sentences.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the silence duration threshold before audio transcription activates from 3 seconds to 10 seconds, allowing for longer natural pauses during recording without interrupting the transcription process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->