### PR TITLE
Add Superhuman app to email providers list

### DIFF
--- a/apps/desktop/src/pipeline/providers/formatting/formatter-prompt.ts
+++ b/apps/desktop/src/pipeline/providers/formatting/formatter-prompt.ts
@@ -274,6 +274,7 @@ const BUNDLE_TO_TYPE: Record<string, AppType> = {
   "com.microsoft.Outlook": "email",
   "com.readdle.smartemail": "email",
   "com.google.Gmail": "email",
+  "com.superhuman.electron": "email",
   "com.tinyspeck.slackmacgap": "chat",
   "com.microsoft.teams": "chat",
   "com.facebook.archon": "chat", // Messenger


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email application detection to properly recognize Superhuman Electron as an email application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->