### PR TITLE
feat: cancel hands-free recording with Escape

### DIFF
--- a/apps/desktop/src/main/managers/recording-manager.ts
+++ b/apps/desktop/src/main/managers/recording-manager.ts
@@ -16,6 +16,7 @@ export type RecordingMode = "idle" | "ptt" | "hands-free";
 export type TerminationCode =
   | "dismissed"
   | "quick_release"
+  | "escape"
   | "no_audio"
   | "error";
 
@@ -110,6 +111,10 @@ export class RecordingManager extends EventEmitter {
     shortcutManager.on("paste-last-transcript-triggered", async () => {
       await this.pasteLatestTranscription();
     });
+
+    shortcutManager.on("escape-triggered", async () => {
+      await this.cancelHandsFreeRecording();
+    });
   }
 
   private setState(newState: RecordingState): void {
@@ -199,6 +204,16 @@ export class RecordingManager extends EventEmitter {
     } else {
       // Normal release - stop and transcribe
       await this.endRecording();
+    }
+  }
+
+  public async cancelHandsFreeRecording() {
+    if (
+      this.recordingState === "recording" &&
+      this.recordingMode === "hands-free"
+    ) {
+      logger.audio.info("Escape pressed in hands-free mode, cancelling");
+      await this.endRecording("escape");
     }
   }
 

--- a/apps/desktop/src/main/managers/shortcut-manager.ts
+++ b/apps/desktop/src/main/managers/shortcut-manager.ts
@@ -13,7 +13,6 @@ import {
 
 const log = logger.main;
 const PRESSED_KEYS_RECHECK_INTERVAL_MS = 10000;
-const ESCAPE_KEY_CODES = new Set([53, 0x1b]);
 
 interface KeyInfo {
   keyCode: number;
@@ -314,7 +313,8 @@ export class ShortcutManager extends EventEmitter {
   private isEscapePressed(): boolean {
     const activeKeysList = this.getActiveKeys();
     return (
-      activeKeysList.length === 1 && ESCAPE_KEY_CODES.has(activeKeysList[0]!)
+      activeKeysList.length === 1 &&
+      getKeyFromKeycode(activeKeysList[0]!) === "Escape"
     );
   }
 

--- a/apps/desktop/src/main/managers/shortcut-manager.ts
+++ b/apps/desktop/src/main/managers/shortcut-manager.ts
@@ -13,6 +13,7 @@ import {
 
 const log = logger.main;
 const PRESSED_KEYS_RECHECK_INTERVAL_MS = 10000;
+const ESCAPE_KEY_CODES = new Set([53, 0x1b]);
 
 interface KeyInfo {
   keyCode: number;
@@ -40,6 +41,7 @@ export class ShortcutManager extends EventEmitter {
   private recheckInFlight = false;
   private recheckInterval: NodeJS.Timeout | null = null;
   private exactMatchState = {
+    escape: false,
     toggleRecording: false,
     pasteLastTranscript: false,
     newNote: false,
@@ -183,6 +185,7 @@ export class ShortcutManager extends EventEmitter {
   setIsRecordingShortcut(isRecording: boolean) {
     this.isRecordingShortcut = isRecording;
     if (isRecording) {
+      this.exactMatchState.escape = false;
       this.exactMatchState.toggleRecording = false;
       this.exactMatchState.pasteLastTranscript = false;
       this.exactMatchState.newNote = false;
@@ -276,6 +279,12 @@ export class ShortcutManager extends EventEmitter {
       return;
     }
 
+    const escapeMatch = this.isEscapePressed();
+    if (escapeMatch && !this.exactMatchState.escape) {
+      this.emit("escape-triggered");
+    }
+    this.exactMatchState.escape = escapeMatch;
+
     // Check PTT shortcut
     const isPTTPressed = this.isPTTShortcutPressed();
     this.emit("ptt-state-changed", isPTTPressed);
@@ -300,6 +309,13 @@ export class ShortcutManager extends EventEmitter {
       this.emit("open-notes-window-triggered");
     }
     this.exactMatchState.newNote = newNoteMatch;
+  }
+
+  private isEscapePressed(): boolean {
+    const activeKeysList = this.getActiveKeys();
+    return (
+      activeKeysList.length === 1 && ESCAPE_KEY_CODES.has(activeKeysList[0]!)
+    );
   }
 
   private isPTTShortcutPressed(): boolean {


### PR DESCRIPTION
## Summary
- Add Escape as a global cancel action while hands-free recording is active
- Discard the active recording via the existing cancellation path instead of stopping/submitting it
- Debounce Escape detection so holding the key only triggers one cancel event

Closes #141

## Test plan
- [x] `pnpm type:check`
- [x] `pnpm lint` (passes with existing warnings)
- [ ] Manual desktop verification: start hands-free recording, press Escape, confirm recording is discarded and app returns to idle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pressing Escape now reliably cancels an active hands-free recording: the session ends immediately, buffered audio is discarded, and the recording is reported as cancelled (no automatic save).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->