### PR TITLE
feat: add Swiss German spelling option (ß → ss) to dictation settings

### DIFF
--- a/apps/desktop/src/db/app-settings.ts
+++ b/apps/desktop/src/db/app-settings.ts
@@ -96,6 +96,7 @@ const defaultSettings: AppSettingsData = {
   dictation: {
     autoDetectEnabled: true,
     languages: ["en"],
+    swissGermanSpelling: false,
   },
   recording: {
     defaultFormat: "wav",

--- a/apps/desktop/src/db/schema.ts
+++ b/apps/desktop/src/db/schema.ts
@@ -185,6 +185,7 @@ export interface AppSettingsData {
   dictation?: {
     autoDetectEnabled: boolean;
     languages: string[]; // Selected dictation languages; empty = auto-detect
+    swissGermanSpelling?: boolean; // Replace \u00df with ss (Swiss Standard German)
   };
   preferences?: {
     launchAtLogin?: boolean;

--- a/apps/desktop/src/i18n/locales/de.json
+++ b/apps/desktop/src/i18n/locales/de.json
@@ -658,7 +658,11 @@
         },
         "languagesLabel": "Sprachen",
         "languagesPlaceholder": "Sprachen auswählen...",
-        "noResults": "Keine Sprachen gefunden."
+        "noResults": "Keine Sprachen gefunden.",
+        "swissGerman": {
+          "label": "Schweizer Rechtschreibung (ß → ss)",
+          "description": "Ersetzt das scharfe S (ß) durch ss, wie in der Schweiz und in Liechtenstein üblich."
+        }
       },
       "microphone": {
         "label": "Mikrofon",

--- a/apps/desktop/src/i18n/locales/en.json
+++ b/apps/desktop/src/i18n/locales/en.json
@@ -658,7 +658,11 @@
         },
         "languagesLabel": "Languages",
         "languagesPlaceholder": "Select languages...",
-        "noResults": "No languages found."
+        "noResults": "No languages found.",
+        "swissGerman": {
+          "label": "Swiss German spelling (ß → ss)",
+          "description": "Replace the German sharp s (ß) with ss, as written in Switzerland and Liechtenstein."
+        }
       },
       "microphone": {
         "label": "Microphone",

--- a/apps/desktop/src/i18n/locales/es.json
+++ b/apps/desktop/src/i18n/locales/es.json
@@ -636,7 +636,11 @@
         },
         "languagesLabel": "Idiomas",
         "languagesPlaceholder": "Seleccionar idiomas...",
-        "noResults": "No se encontraron idiomas."
+        "noResults": "No se encontraron idiomas.",
+        "swissGerman": {
+          "label": "Ortografía suiza (ß → ss)",
+          "description": "Reemplaza la eszett alemana (ß) por ss, como se escribe en Suiza y Liechtenstein."
+        }
       },
       "microphone": {
         "label": "Micrófono",

--- a/apps/desktop/src/i18n/locales/ja.json
+++ b/apps/desktop/src/i18n/locales/ja.json
@@ -636,7 +636,11 @@
         },
         "languagesLabel": "言語",
         "languagesPlaceholder": "言語を選択...",
-        "noResults": "言語が見つかりません。"
+        "noResults": "言語が見つかりません。",
+        "swissGerman": {
+          "label": "スイス式ドイツ語表記（ß → ss）",
+          "description": "ドイツ語のエスツェット（ß）を、スイスとリヒテンシュタインで使われる ss に置き換えます。"
+        }
       },
       "microphone": {
         "label": "マイク",

--- a/apps/desktop/src/i18n/locales/zh-TW.json
+++ b/apps/desktop/src/i18n/locales/zh-TW.json
@@ -636,7 +636,11 @@
         },
         "languagesLabel": "語言",
         "languagesPlaceholder": "選擇語言...",
-        "noResults": "找不到語言。"
+        "noResults": "找不到語言。",
+        "swissGerman": {
+          "label": "瑞士德語拼寫（ß → ss）",
+          "description": "將德語字母 ß 替換為瑞士和列支敦斯登使用的 ss。"
+        }
       },
       "microphone": {
         "label": "麥克風",

--- a/apps/desktop/src/pipeline/core/context.ts
+++ b/apps/desktop/src/pipeline/core/context.ts
@@ -16,6 +16,7 @@ export interface SharedPipelineData {
   replacements: Map<string, string>; // Custom replacements
   userPreferences: {
     languages?: string[]; // Selected dictation languages; empty/undefined = auto-detect
+    swissGermanSpelling?: boolean; // Replace \u00df with ss (Swiss Standard German)
     formattingStyle: "formal" | "casual" | "technical";
   };
   audioMetadata: {
@@ -36,6 +37,7 @@ export function createDefaultContext(sessionId: string): PipelineContext {
       replacements: new Map(),
       userPreferences: {
         languages: undefined,
+        swissGermanSpelling: false,
         formattingStyle: "formal",
       },
       audioMetadata: {

--- a/apps/desktop/src/renderer/main/pages/settings/dictation/components/LanguageSettings.tsx
+++ b/apps/desktop/src/renderer/main/pages/settings/dictation/components/LanguageSettings.tsx
@@ -34,16 +34,19 @@ export function LanguageSettings() {
 
   const [languages, setLanguages] = useState<string[]>(["en"]);
   const [autoDetect, setAutoDetect] = useState(true);
+  const [swissGerman, setSwissGerman] = useState(false);
 
   useEffect(() => {
     if (dictationSettings) {
       setLanguages(dictationSettings.languages);
       setAutoDetect(dictationSettings.autoDetectEnabled);
+      setSwissGerman(dictationSettings.swissGermanSpelling ?? false);
     }
   }, [dictationSettings]);
 
   const persist = async (next: {
     autoDetectEnabled: boolean;
+    swissGermanSpelling: boolean;
     languages: string[];
   }) => {
     try {
@@ -51,18 +54,36 @@ export function LanguageSettings() {
     } catch (error) {
       setLanguages(dictationSettings?.languages ?? []);
       setAutoDetect(dictationSettings?.autoDetectEnabled ?? true);
+      setSwissGerman(dictationSettings?.swissGermanSpelling ?? false);
       console.error("Failed to update dictation settings:", error);
     }
   };
 
   const handleAutoDetectChange = async (enabled: boolean) => {
     setAutoDetect(enabled);
-    await persist({ autoDetectEnabled: enabled, languages });
+    await persist({
+      autoDetectEnabled: enabled,
+      swissGermanSpelling: swissGerman,
+      languages,
+    });
   };
 
   const handleLanguagesChange = async (next: string[]) => {
     setLanguages(next);
-    await persist({ autoDetectEnabled: autoDetect, languages: next });
+    await persist({
+      autoDetectEnabled: autoDetect,
+      swissGermanSpelling: swissGerman,
+      languages: next,
+    });
+  };
+
+  const handleSwissGermanChange = async (enabled: boolean) => {
+    setSwissGerman(enabled);
+    await persist({
+      autoDetectEnabled: autoDetect,
+      swissGermanSpelling: enabled,
+      languages,
+    });
   };
 
   const disabled = autoDetect || isLoading || updateDictationSettings.isPending;
@@ -141,6 +162,22 @@ export function LanguageSettings() {
             </ComboboxBase>
           </div>
         </div>
+      </div>
+
+      <div className="mt-6 flex items-center justify-between">
+        <div>
+          <Label className="text-sm font-medium text-foreground">
+            {t("settings.dictation.language.swissGerman.label")}
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            {t("settings.dictation.language.swissGerman.description")}
+          </p>
+        </div>
+        <Switch
+          checked={swissGerman}
+          onCheckedChange={handleSwissGermanChange}
+          disabled={busy}
+        />
       </div>
     </div>
   );

--- a/apps/desktop/src/services/transcription-service.ts
+++ b/apps/desktop/src/services/transcription-service.ts
@@ -30,7 +30,10 @@ import { Mutex } from "async-mutex";
 import { dialog } from "electron";
 import { AVAILABLE_MODELS } from "../constants/models";
 import { AppError, ErrorCodes } from "../types/error";
-import { applyTextReplacements } from "../utils/text-replacement";
+import {
+  applySwissGermanSpelling,
+  applyTextReplacements,
+} from "../utils/text-replacement";
 import { normalizeTranscriptionBoundaries } from "../utils/boundary-spacing";
 import { selectVocabularyHints } from "../utils/vocabulary-hints";
 import * as fs from "node:fs";
@@ -517,6 +520,8 @@ export class TranscriptionService {
         replacements: session.context.sharedData.replacements,
         formattingStyle:
           session.context.sharedData.userPreferences?.formattingStyle,
+        swissGermanSpelling:
+          session.context.sharedData.userPreferences?.swissGermanSpelling,
       });
       // Final post-format pass: normalize boundary whitespace based on the
       // insertion context. Runs after formatting + replacements so the emitted
@@ -699,6 +704,8 @@ export class TranscriptionService {
       dictationSettings.autoDetectEnabled || languages.length === 0
         ? undefined
         : languages;
+    context.sharedData.userPreferences.swissGermanSpelling =
+      dictationSettings.swissGermanSpelling ?? false;
 
     // Load vocabulary — every entry the user has authored should participate
     // in replacement; caps belong on the create path, not here.
@@ -777,6 +784,7 @@ export class TranscriptionService {
     accessibilityContext?: StreamingSession["context"]["sharedData"]["accessibilityContext"];
     replacements: Map<string, string>;
     formattingStyle?: string;
+    swissGermanSpelling?: boolean;
   }): Promise<{
     text: string;
     textBeforeReplacements: string;
@@ -865,6 +873,13 @@ export class TranscriptionService {
           );
         }
       }
+    }
+
+    // Swiss Standard German orthography: replace \u00df with ss. Runs after
+    // formatting (the language model may emit \u00df) and before vocabulary
+    // replacements so user replacements match the normalized text.
+    if (options.swissGermanSpelling) {
+      text = applySwissGermanSpelling(text);
     }
 
     const textBeforeReplacements = text;
@@ -1064,6 +1079,8 @@ export class TranscriptionService {
       vocabulary,
       replacements: context.sharedData.replacements,
       formattingStyle: context.sharedData.userPreferences?.formattingStyle,
+      swissGermanSpelling:
+        context.sharedData.userPreferences?.swissGermanSpelling,
     });
 
     // Final post-format pass, mirroring finalizeSession. Re-transcription has no

--- a/apps/desktop/src/trpc/routers/settings.ts
+++ b/apps/desktop/src/trpc/routers/settings.ts
@@ -52,6 +52,7 @@ const ModelProvidersConfigSchema = z.object({
 
 const DictationSettingsSchema = z.object({
   autoDetectEnabled: z.boolean(),
+  swissGermanSpelling: z.boolean().optional().default(false),
   languages: z.array(
     z
       .string()
@@ -448,6 +449,7 @@ export const settingsRouter = createRouter({
       }
       return {
         autoDetectEnabled: true,
+        swissGermanSpelling: false,
         languages: ["en"],
       };
     }
@@ -466,6 +468,7 @@ export const settingsRouter = createRouter({
 
         const dictationSettings = {
           autoDetectEnabled: input.autoDetectEnabled,
+          swissGermanSpelling: input.swissGermanSpelling,
           languages: input.languages,
         };
 

--- a/apps/desktop/src/utils/text-replacement.ts
+++ b/apps/desktop/src/utils/text-replacement.ts
@@ -53,3 +53,18 @@ export function applyTextReplacements(
 
   return result;
 }
+
+/**
+ * Replace the German sharp s with its Swiss Standard German spelling.
+ *
+ * Swiss Standard German (Switzerland and Liechtenstein) does not use the
+ * sharp s at all: every ß is written ss. Because the sharp s only ever
+ * appears inside words, the word-boundary matching in applyTextReplacements
+ * cannot express this rule, so it gets its own character-level pass.
+ */
+export function applySwissGermanSpelling(text: string): string {
+  if (!text) {
+    return text;
+  }
+  return text.replace(/\u00df/gu, "ss").replace(/\u1e9e/gu, "SS");
+}

--- a/apps/desktop/tests/utils/text-replacement.test.ts
+++ b/apps/desktop/tests/utils/text-replacement.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { applyTextReplacements } from "../../src/utils/text-replacement";
+import {
+  applySwissGermanSpelling,
+  applyTextReplacements,
+} from "../../src/utils/text-replacement";
 
 describe("applyTextReplacements", () => {
   describe("English (alphabetic languages)", () => {
@@ -220,5 +223,33 @@ describe("applyTextReplacements", () => {
       const result = applyTextReplacements("foo", replacements);
       expect(result).toBe("a $` b $' c");
     });
+  });
+});
+
+describe("applySwissGermanSpelling", () => {
+  it("should replace \u00df with ss inside words", () => {
+    expect(applySwissGermanSpelling("Die Stra\u00dfe ist gro\u00df")).toBe(
+      "Die Strasse ist gross",
+    );
+  });
+
+  it("should replace capital \u1e9e with SS", () => {
+    expect(applySwissGermanSpelling("STRA\u1e9eE")).toBe("STRASSE");
+  });
+
+  it("should replace multiple occurrences", () => {
+    expect(
+      applySwissGermanSpelling("Au\u00dferdem hei\u00dft das Ma\u00dfnahme"),
+    ).toBe("Ausserdem heisst das Massnahme");
+  });
+
+  it("should leave text without sharp s untouched", () => {
+    expect(applySwissGermanSpelling("Das ist schon Schweizer Text")).toBe(
+      "Das ist schon Schweizer Text",
+    );
+  });
+
+  it("should handle empty strings", () => {
+    expect(applySwissGermanSpelling("")).toBe("");
   });
 });


### PR DESCRIPTION
## Why

Swiss Standard German (Switzerland and Liechtenstein) does not use the sharp s at all — every ß is written ss (Strasse, gross, weiss). Today there is no way to get Swiss spelling out of Amical:

- The speech and formatting models emit standard German orthography with ß.
- Vocabulary replacements can't fix it: they match whole words only (word-boundary regex in `applyTextReplacements`), and ß only ever appears inside a word, so a `ß → ss` replacement entry never fires. Adding every inflected ß word as a separate replacement doesn't scale.

## What

A new toggle in **Settings → Dictation** (Languages section): **Swiss German spelling (ß → ss)**. Off by default.

When enabled, `ß`/`ẞ` are replaced with `ss`/`SS` as a character-level post-processing pass:

- runs **after AI formatting**, because the language model may (re)introduce ß
- runs **before vocabulary replacements**, so user replacements match the normalized text

## Implementation notes

- `applySwissGermanSpelling()` in `utils/text-replacement.ts`, applied in `applyFormattingAndReplacements` (covers both `finalizeSession` and `retryTranscription`)
- New optional `dictation.swissGermanSpelling` setting (defaults to `false` everywhere it's read, so **no settings migration** is needed)
- Threaded through `DictationSettingsSchema` (tRPC) and `SharedPipelineData.userPreferences`
- Toggle UI in `LanguageSettings.tsx`, strings added for en/de/es/ja/zh-TW
- Unit tests for the new function in `tests/utils/text-replacement.test.ts`

## Testing

- `vitest`: all 30 tests in `text-replacement.test.ts` pass (25 existing + 5 new)
- Locale JSON validated, new hunks are prettier-clean
- Not verified: full app build / manual UI test (toggle rendering in the Languages card should be double-checked)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Swiss German spelling option for dictation settings. When enabled, the German sharp s character (ß) is automatically replaced with "ss" during transcription to conform to Swiss Standard German conventions.

* **Localization**
  * Added translations for the new Swiss German spelling feature in German, English, Spanish, Japanese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->