### PR TITLE
fix: stop feeding running ASR output back as Whisper initial prompt (repetition loops)

### DIFF
--- a/apps/desktop/src/pipeline/providers/transcription/amical-cloud-provider.ts
+++ b/apps/desktop/src/pipeline/providers/transcription/amical-cloud-provider.ts
@@ -1030,7 +1030,9 @@ export class AmicalCloudProvider implements TranscriptionProvider {
               vadProbs,
               languages: snapshot.currentLanguages,
               vocabulary: snapshot.currentVocabulary,
-              previousTranscription: snapshot.currentAggregatedTranscription,
+              // Not sent: conditioning on the running ASR output can seed a
+              // self-reinforcing repetition loop on the server side too.
+              previousTranscription: undefined,
               formatting: {
                 enabled: enableFormatting,
               },

--- a/apps/desktop/src/pipeline/providers/transcription/whisper-provider.ts
+++ b/apps/desktop/src/pipeline/providers/transcription/whisper-provider.ts
@@ -286,9 +286,15 @@ export class WhisperProvider implements TranscriptionProvider {
     aggregatedTranscription?: string,
     accessibilityContext?: TranscribeContext["accessibilityContext"],
   ): string {
+    // NOTE: previousTranscription (the running ASR output) is intentionally not
+    // fed back as the initial prompt. Conditioning Whisper on its own prior
+    // output lets a single hallucinated phrase self-reinforce into a repetition
+    // loop across windows. Vocabulary and cursor context are static, so they
+    // stay. See whisper repetition-hallucination behavior.
+    void aggregatedTranscription;
     const prompt = buildWhisperPrompt({
       vocabulary,
-      previousTranscription: aggregatedTranscription,
+      previousTranscription: undefined,
       beforeText:
         accessibilityContext?.context?.textSelection?.preSelectionText,
     });


### PR DESCRIPTION
## Problem

Whisper can fall into a **repetition loop**: once it emits a phrase, that phrase reappears every window until the audio ends. In our use this wiped out large stretches of real speech — a 56‑minute Japanese recording had minutes 20–47 replaced entirely by `はいはいはい…`‑style loops, even though the audio was clear and well above the noise floor (the loop region measured −25 dB RMS vs −24 dB in a clean region, so it was **not** a volume problem).

The trigger is self‑conditioning. `generateInitialPrompt()` (local Whisper) and the Amical Cloud request both feed the **running ASR output** (`previousTranscription` / `currentAggregatedTranscription`) back in as the next window's prompt. When a hallucinated phrase slips in, re‑injecting it as context makes Whisper far more likely to emit it again, which re‑injects it again — a self‑reinforcing loop. whisper.cpp's own `no_context` default is `true` precisely to avoid this; the app re‑introduces the carry‑over at the application layer.

## Change

Stop feeding the running transcription back as the initial prompt, in both providers:

- `whisper-provider.ts` – `generateInitialPrompt()` no longer passes `previousTranscription`.
- `amical-cloud-provider.ts` – the request sends `previousTranscription: undefined`.

**Vocabulary and cursor context (`beforeText`) are preserved** — those are static and don't loop, so spelling/term hints still work.

## Verification

Built from this branch (local Whisper, large‑v3, Metal) and re‑transcribed the same recording: the previously‑lost minutes came back as clean Japanese with **no repetition loops** (~5.8× more real text recovered). Equivalent to running whisper.cpp with `no_context=true`, which is its default.

## Tradeoff / open question

This is the minimal fix and disables cross‑window context entirely. There's a small coherence cost (the model no longer "remembers" the last few words across a long dictation). If you'd prefer to keep some context, happy to rework this as:

- a **setting** (`conditionOnPreviousText`, default off), or
- a **guarded** injection — only carry context when the previous window wasn't flagged as low‑confidence / a detected n‑gram repeat.

Let me know which direction you'd prefer and I'll adjust.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated transcription processing to remove context carry-over between transcription calls, eliminating self-reinforcement behavior in audio transcription.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->