### PR TITLE
fix(desktop): update bundled Node.js to 22.23.2

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -25,6 +25,10 @@ import {
   copyFileSync,
 } from "node:fs";
 import { join, normalize } from "node:path";
+import {
+  downloadNodeBinary,
+  getCurrentPlatform,
+} from "./scripts/download-node-binaries";
 import { stageBetterSqlite3ForElectron } from "./scripts/stage-better-sqlite3";
 // Use flora-colossus for finding all dependencies of EXTERNAL_DEPENDENCIES
 // flora-colossus is maintained by MarshallOfSound (a top electron-forge contributor)
@@ -65,6 +69,16 @@ const config: ForgeConfig = {
             `(host: ${process.platform}-${process.arch}, target: ${platform}-${arch}).`,
         );
       }
+
+      // extraResource below selects the host-specific binary. Refresh that
+      // exact resource before Forge verifies and copies it into the package.
+      const nodePlatform = getCurrentPlatform();
+      if (!nodePlatform) {
+        throw new Error(
+          `Unsupported Node.js binary host: ${process.platform}-${process.arch}`,
+        );
+      }
+      await downloadNodeBinary(nodePlatform);
 
       // The start script stages the same physical copy before Forge loads.
       // Refresh it here too so packaging never reuses stale ABI metadata.

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -23,11 +23,12 @@ import {
   lstatSync,
   readlinkSync,
   copyFileSync,
+  chmodSync,
 } from "node:fs";
-import { join, normalize } from "node:path";
+import { dirname, join, normalize } from "node:path";
 import {
   downloadNodeBinary,
-  getCurrentPlatform,
+  PLATFORMS,
 } from "./scripts/download-node-binaries";
 import { stageBetterSqlite3ForElectron } from "./scripts/stage-better-sqlite3";
 // Use flora-colossus for finding all dependencies of EXTERNAL_DEPENDENCIES
@@ -41,7 +42,7 @@ let nativeModuleDependenciesToPackage: string[] = [];
 const isBundledNodeBinaryForSigning = (filePath: string): boolean => {
   const normalizedPath = filePath.replace(/\\/g, "/");
 
-  // extraResource copies the selected binary into Contents/Resources/node.
+  // packageAfterCopy places the binary in Contents/Resources/node.
   return normalizedPath.endsWith("/Contents/Resources/node");
 };
 
@@ -70,41 +71,9 @@ const config: ForgeConfig = {
         );
       }
 
-      // extraResource below selects the host-specific binary. Refresh that
-      // exact resource before Forge verifies and copies it into the package.
-      const nodePlatform = getCurrentPlatform();
-      if (!nodePlatform) {
-        throw new Error(
-          `Unsupported Node.js binary host: ${process.platform}-${process.arch}`,
-        );
-      }
-      await downloadNodeBinary(nodePlatform);
-
       // The start script stages the same physical copy before Forge loads.
       // Refresh it here too so packaging never reuses stale ABI metadata.
       stageBetterSqlite3ForElectron();
-
-      // Copy platform-specific Node.js binary
-      console.log(`Copying Node.js binary for ${platform}-${arch}...`);
-      const nodeBinarySource = join(
-        projectRoot,
-        "node-binaries",
-        `${platform}-${arch}`,
-        platform === "win32" ? "node.exe" : "node",
-      );
-
-      // Check if the binary exists
-      if (existsSync(nodeBinarySource)) {
-        console.log(`✓ Node.js binary found for ${platform}-${arch}`);
-      } else {
-        console.error(
-          `✗ Node.js binary not found for ${platform}-${arch} at ${nodeBinarySource}`,
-        );
-        console.error(
-          `  Please run 'pnpm download-node' or 'pnpm download-node:all' first`,
-        );
-        throw new Error(`Missing Node.js binary for ${platform}-${arch}`);
-      }
 
       const getExternalNestedDependencies = async (
         nodeModuleNames: string[],
@@ -302,6 +271,43 @@ const config: ForgeConfig = {
           "Skipping onnxruntime-node pruning, bin directory not found.",
         );
       }
+    },
+    packageAfterCopy: async (
+      _forgeConfig,
+      buildPath,
+      _electronVersion,
+      platform,
+      arch,
+    ) => {
+      const nodePlatform = PLATFORMS.find(
+        (candidate) =>
+          candidate.platform === platform && candidate.arch === arch,
+      );
+      if (!nodePlatform) {
+        throw new Error(
+          `Unsupported Node.js binary target: ${platform}-${arch}`,
+        );
+      }
+
+      await downloadNodeBinary(nodePlatform);
+
+      const binaryName = platform === "win32" ? "node.exe" : "node";
+      const binarySource = join(
+        __dirname,
+        "node-binaries",
+        `${platform}-${arch}`,
+        binaryName,
+      );
+      const binaryDestination = join(dirname(buildPath), binaryName);
+
+      copyFileSync(binarySource, binaryDestination);
+      if (platform !== "win32") {
+        chmodSync(binaryDestination, 0o755);
+      }
+
+      console.log(
+        `✓ Node.js binary prepared for ${platform}-${arch} at ${binaryDestination}`,
+      );
     },
     // NOTE: This hook does NOT run when prune: false is set in packagerConfig (line 467).
     // The empty directory cleanup code below is currently dead code.
@@ -598,10 +604,6 @@ const config: ForgeConfig = {
     extraResource: [
       `${process.platform === "win32" ? "../../packages/native-helpers/windows-helper/bin" : "../../packages/native-helpers/swift-helper/bin"}`,
       "./src/db/migrations",
-      // Only include the platform-specific node binary
-      `./node-binaries/${process.platform}-${process.arch}/node${
-        process.platform === "win32" ? ".exe" : ""
-      }`,
       "./models",
       "./assets",
     ],

--- a/apps/desktop/node-binaries/README.md
+++ b/apps/desktop/node-binaries/README.md
@@ -30,6 +30,10 @@ pnpm download-node
 pnpm download-node:all
 ```
 
+Downloaded binaries are reused only when their local version marker matches the
+version configured by the download script. Version bumps therefore refresh
+existing binaries automatically.
+
 ## Purpose
 
 These binaries are used to spawn a separate Node.js process for Whisper transcription, providing:
@@ -41,4 +45,4 @@ These binaries are used to spawn a separate Node.js process for Whisper transcri
 
 ## Version
 
-Currently using Node.js v22.17.0 LTS binaries.
+Currently using Node.js v22.23.2 LTS binaries.

--- a/apps/desktop/scripts/download-node-binaries.ts
+++ b/apps/desktop/scripts/download-node-binaries.ts
@@ -8,7 +8,7 @@ import { pipeline } from "node:stream/promises";
 import { createWriteStream, mkdirSync, chmodSync } from "node:fs";
 
 // Node.js version to download
-const NODE_VERSION = "22.17.0";
+const NODE_VERSION = "22.23.2";
 
 // Platform/arch types
 type Platform = "darwin" | "win32" | "linux";
@@ -167,11 +167,25 @@ async function downloadNodeBinary(config: PlatformConfig): Promise<void> {
     platformDir,
     platform === "win32" ? "node.exe" : "node",
   );
+  const versionPath = path.join(platformDir, ".node-version");
 
-  // Skip if already exists
-  if (fs.existsSync(binaryPath)) {
-    console.log(`✓ ${platform}-${arch} binary already exists`);
+  // Reuse only binaries downloaded for the configured Node.js version.
+  const installedVersion = fs.existsSync(versionPath)
+    ? fs.readFileSync(versionPath, "utf8").trim()
+    : undefined;
+  if (fs.existsSync(binaryPath) && installedVersion === NODE_VERSION) {
+    console.log(
+      `✓ ${platform}-${arch} binary already exists (v${NODE_VERSION})`,
+    );
     return;
+  }
+
+  if (fs.existsSync(binaryPath)) {
+    console.log(
+      `↻ Updating ${platform}-${arch} binary from ${
+        installedVersion ? `v${installedVersion}` : "an unknown version"
+      } to v${NODE_VERSION}`,
+    );
   }
 
   console.log(`\nDownloading Node.js for ${platform}-${arch}...`);
@@ -216,6 +230,8 @@ async function downloadNodeBinary(config: PlatformConfig): Promise<void> {
     if (platform !== "win32") {
       chmodSync(binaryPath, "755");
     }
+
+    fs.writeFileSync(versionPath, `${NODE_VERSION}\n`, "utf8");
 
     // Clean up
     fs.rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- update the bundled Whisper worker runtime from Node.js 22.17.0 to the 22.23.2 LTS security release
- record the downloaded version per platform so stale ignored binaries are refreshed automatically after future version bumps
- prepare and copy the concrete package target's Node.js binary from Forge's target-specific `packageAfterCopy` hook
- update the bundled-runtime documentation

## Root cause and impact

The downloader pinned Node.js 22.17.0, which caused fresh desktop packages to include that older runtime as `resources/node.exe` on Windows. It also reused any existing local binary based only on file presence, so a developer build could keep packaging an outdated runtime after the pin changed.

New macOS, Windows x64/ARM64, and Linux downloads now resolve to 22.23.2. Forge resolves each concrete package target, refreshes that target's binary, and copies the same file into the target's resources directory. Download or unsupported-target failures abort packaging. This does not change the Node.js 24 build toolchain used by the repository and CI.

Node.js lists 22.23.2 as an LTS security release: https://nodejs.org/en/blog/release/v22.23.2

## Validation

- `pnpm type:check`
- `pnpm --filter @amical/desktop lint` (passes with existing warnings)
- Prettier check for all three changed files
- `git diff --check`
- downloader refresh path followed by cached reuse path
- target hook smoke tests for macOS ARM64 and x64; both copied binaries have the expected Mach-O architecture and report `v22.23.2`
- unsupported target is rejected by the package hook
- all five generated Node.js artifact URLs return HTTP 200

Fixes #174


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the bundled Node.js runtime to version 22.23.2.
  * Improved binary reuse by checking the locally recorded version and automatically refreshing outdated or incomplete installations.

* **Documentation**
  * Updated setup documentation to describe binary reuse and version-based refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
