### PR TITLE
fix(desktop): honor pinned Whisper language

### DIFF
--- a/apps/desktop/src/pipeline/providers/transcription/whisper-prompt.ts
+++ b/apps/desktop/src/pipeline/providers/transcription/whisper-prompt.ts
@@ -59,6 +59,11 @@ export function sanitizeWhisperPrompt(prompt: string): string {
 }
 
 export interface BuildWhisperPromptOptions {
+  /** Candidate language codes passed to Whisper. Exactly one entry forces
+   * that language; in that mode target-app text is excluded because it can
+   * override the explicit language token. */
+  languages?: readonly string[];
+
   /** Domain vocabulary / hotwords (proper nouns, jargon). Joined with ", ".
    * Placed at the START of the prompt: less critical for continuity than the
    * prior-transcript tail, and if byte truncation hits, the start gets dropped
@@ -97,7 +102,8 @@ export function buildWhisperPrompt(
     if (vocab) parts.push(vocab);
   }
 
-  const source = opts.previousTranscription || opts.beforeText;
+  const beforeText = opts.languages?.length === 1 ? undefined : opts.beforeText;
+  const source = opts.previousTranscription || beforeText;
   if (source) {
     const words = source.trim().split(/\s+/).filter(Boolean);
     const n = opts.previousWordCount ?? DEFAULT_PREVIOUS_WORD_COUNT;

--- a/apps/desktop/src/pipeline/providers/transcription/whisper-provider.ts
+++ b/apps/desktop/src/pipeline/providers/transcription/whisper-provider.ts
@@ -185,6 +185,7 @@ export class WhisperProvider implements TranscriptionProvider {
 
       // Generate initial prompt from recent context only (align with cloud)
       const initialPrompt = this.generateInitialPrompt(
+        languages,
         context.vocabulary,
         aggregatedTranscription,
         context.accessibilityContext,
@@ -292,11 +293,13 @@ export class WhisperProvider implements TranscriptionProvider {
   }
 
   private generateInitialPrompt(
+    languages?: readonly string[],
     vocabulary?: readonly string[],
     aggregatedTranscription?: string,
     accessibilityContext?: TranscribeContext["accessibilityContext"],
   ): string {
     const prompt = buildWhisperPrompt({
+      languages,
       vocabulary,
       previousTranscription: aggregatedTranscription,
       beforeText:

--- a/apps/desktop/tests/pipeline/whisper-prompt.test.ts
+++ b/apps/desktop/tests/pipeline/whisper-prompt.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { buildWhisperPrompt } from "../../src/pipeline/providers/transcription/whisper-prompt";
+
+describe("buildWhisperPrompt language conditioning", () => {
+  it("omits target-app text when exactly one language is forced", () => {
+    expect(
+      buildWhisperPrompt({
+        languages: ["ru"],
+        beforeText: "ctrl esc to focus or unfocus Claude",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps vocabulary and previous transcription for a forced language", () => {
+    expect(
+      buildWhisperPrompt({
+        languages: ["ru"],
+        vocabulary: ["Amical", "Whisper"],
+        previousTranscription: "предыдущая русская фраза",
+        beforeText: "Write a message in English",
+      }),
+    ).toBe("Amical, Whisper. предыдущая русская фраза");
+  });
+
+  it.each([
+    ["auto-detection", undefined],
+    ["an empty language list", []],
+    ["constrained multi-language detection", ["en", "ru"]],
+  ])("keeps target-app text for %s", (_label, languages) => {
+    expect(
+      buildWhisperPrompt({
+        languages,
+        beforeText: "Write a message in English",
+      }),
+    ).toBe("Write a message in English");
+  });
+});

--- a/apps/desktop/tests/pipeline/whisper-provider.test.ts
+++ b/apps/desktop/tests/pipeline/whisper-provider.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GetAccessibilityContextResult } from "@amical/types";
+import type { ModelService } from "../../src/services/model-service";
+import type { TranscribeContext } from "../../src/pipeline/core/pipeline-types";
+import { WhisperProvider } from "../../src/pipeline/providers/transcription/whisper-provider";
+
+const targetAppContext = {
+  context: {
+    textSelection: {
+      preSelectionText: "ctrl esc to focus or unfocus Claude",
+    },
+  },
+} as unknown as GetAccessibilityContextResult;
+
+describe("WhisperProvider initial prompt", () => {
+  it("does not send target-app text when one language is forced", async () => {
+    const provider = new WhisperProvider({} as ModelService);
+    const exec = vi.fn().mockResolvedValue({ text: "тест" });
+
+    vi.spyOn(provider, "initializeWhisper").mockResolvedValue();
+    Object.assign(provider, { workerWrapper: { exec } });
+
+    const context: TranscribeContext = {
+      languages: ["ru"],
+      vocabulary: ["Amical"],
+      accessibilityContext: targetAppContext,
+    };
+
+    for (let frame = 0; frame < 3; frame++) {
+      await provider.transcribe({
+        audioData: new Float32Array(512).fill(0.1),
+        speechProbability: 1,
+        context,
+      });
+    }
+    await provider.flush(context);
+
+    const transcribeCall = exec.mock.calls.find(
+      ([method]) => method === "transcribeAudio",
+    );
+    expect(transcribeCall).toBeDefined();
+    expect(transcribeCall?.[1][1]).toMatchObject({
+      languages: ["ru"],
+      initial_prompt: "Amical",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- exclude target-app pre-cursor text from local Whisper's `initial_prompt` when exactly one dictation language is pinned
- retain explicit vocabulary and prior-transcription context for continuity
- preserve the existing prompt behavior for unrestricted and constrained multi-language auto-detection
- add unit and provider-level regression coverage for the language/prompt interaction

## Root cause

The pinned `languages` value reached the local Whisper worker correctly, but the prompt builder independently included accessibility `preSelectionText`. English UI hints could therefore condition the decoder more strongly than the forced language token.

## User impact

With auto-detect disabled and one language selected, unrelated text exposed by the target app no longer pulls local transcription into a different language. Vocabulary and previous dictated text still condition the model as intended.

## Validation

- regression test reproduced the English UI prompt before the fix
- focused Vitest suite: 6/6 tests passed
- full desktop Vitest suite: 69 files, 632/632 tests passed
- repository typecheck passed under Node 24 / pnpm 10.15.0
- desktop ESLint passed with 0 errors (existing warnings remain)
- targeted Prettier check and `git diff --check` passed

Fixes #170


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Whisper transcription when a single language is selected.
  * Initial prompts now prioritize the selected language, vocabulary, and previous transcription.
  * Unrelated target-application text is excluded in single-language mode for more focused results.
  * Automatic language detection and multi-language configurations continue to include relevant context.

* **Tests**
  * Added coverage for single-language, multi-language, empty-language, and automatic detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->